### PR TITLE
[Added] mount to config as first step to remove Enzyme

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,31 @@
-let config
+import { mount } from 'enzyme'
+
+const mountUsingEnzyme = Component => {
+  const componentMounted = mount(Component)
+
+  componentMounted.asyncFind = selector => {
+    return new Promise(resolve => {
+      setImmediate(() => {
+        componentMounted.update()
+
+        resolve(componentMounted.find(selector))
+      })
+    })
+  }
+
+  return componentMounted
+}
+
+let config = {
+  defaultHost: '',
+  mount: mountUsingEnzyme,
+  defaultStore: {},
+  reducers: null,
+}
 
 function configureMocks(newConfig) {
   config = {
-    defaultHost: '',
+    ...config,
     ...newConfig,
   }
 }

--- a/src/wrap.js
+++ b/src/wrap.js
@@ -1,10 +1,10 @@
 import React from 'react'
-import { mount as _mount } from 'enzyme'
 import { Provider } from 'react-redux'
 
 import { mockStore } from './mockStore'
 import { MockRouter } from './mockRouter'
 import { mockFetch } from './mockFetch'
+import { getMocksConfig } from './config'
 
 const wrap = options => {
   const isComponent = typeof options === 'function'
@@ -53,35 +53,19 @@ function setupPortal(portalRootId) {
   document.body.appendChild(portalRoot)
 }
 
-const asyncMount = Component => {
-  const componentMounted = _mount(Component)
+const mount = ({ Component, props }) => getMocksConfig().mount(<Component { ...props } />)
 
-  componentMounted.asyncFind = selector => {
-    return new Promise(resolve => {
-      setImmediate(() => {
-        componentMounted.update()
-
-        resolve(componentMounted.find(selector))
-      })
-    })
-  }
-
-  return componentMounted
-}
-
-const mount = ({ Component, props }) => asyncMount(<Component { ...props } />)
-
-const mountWithRouter = ({ Component, props: componentProps, routing }) => asyncMount(
+const mountWithRouter = ({ Component, props: componentProps, routing }) => getMocksConfig().mount(
   <MockRouter { ...{ Component, routing, componentProps } } />
 )
 
-const mountWithStore = ({ Component, props, store }) => asyncMount(
+const mountWithStore = ({ Component, props, store }) => getMocksConfig().mount(
   <Provider store={ mockStore(store) }>
     <Component { ...props } />
   </Provider>
 )
 
-const mountWithStoreAndRouter = ({ Component, props: componentProps, store, routing }) => asyncMount(
+const mountWithStoreAndRouter = ({ Component, props: componentProps, store, routing }) => getMocksConfig().mount(
   <Provider store={ mockStore(store) }>
     <MockRouter { ...{ Component, routing, componentProps } } />
   </Provider>

--- a/tests/wrap.test.js
+++ b/tests/wrap.test.js
@@ -1,9 +1,13 @@
-import { wrap, configureMocks } from '../src/index'
-import { MyComponent, MyAsyncComponent, MyComponentMakingHttpCalls } from './components.mock'
+import { render } from 'react-dom'
 import { combineReducers } from 'redux'
+import { wrap, configureMocks } from '../src/index'
+import { getMocksConfig } from '../src/config'
+import { MyComponent, MyAsyncComponent, MyComponentMakingHttpCalls } from './components.mock'
+
+const defaultMocksConfig = getMocksConfig()
 
 function resetMocksConfig() {
-  configureMocks(null)
+  configureMocks(defaultMocksConfig)
 }
 
 describe('wrap', () => {
@@ -150,5 +154,32 @@ describe('wrap', () => {
 
     const successIconAfterSave = (await myComponentMakingHttpCalls.asyncFind('[aria-label="quantity saved"]'))
     expect(successIconAfterSave).toHaveLength(1)
+  })
+
+  it('should use Enzyme by default', () => {
+    const expectedText = 'Foo'
+    const mountedWithEnzymeComponent = wrap(MyComponent).mount()
+
+    const textFoundByUsingEnzymeAPI = mountedWithEnzymeComponent.text()
+
+    expect(textFoundByUsingEnzymeAPI).toBe(expectedText)
+  })
+
+  it('should use a custom mount', () => {
+    function mountUsingNativeBrowserAPI(component) {
+      const rootNode = document.body.appendChild(document.createElement('div'))
+
+      render(component, rootNode)
+
+      return rootNode
+    }
+
+    configureMocks({ mount: mountUsingNativeBrowserAPI })
+    const expectedText = 'Foo'
+    const mountedWithNativeBrowserAPIComponent = wrap(MyComponent).mount()
+
+    const textFoundByUsingNativeBrowserAPI = mountedWithNativeBrowserAPIComponent.textContent
+
+    expect(textFoundByUsingNativeBrowserAPI).toBe(expectedText)
   })
 })


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Added mount to config as first step to remove Enzyme

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This way we can pass a mount function and burrito will mount using it. It has a default mount function that is basically our former `asyncMount` using `Enzyme` for backward compatibility sake.

Now we can start using other libraries in our projects. Further steps are:
- Remove Enzyme usage in burrito
- Change default mount so that it uses native browser api instead of Enzyme
- Remove Enzyme dependency from burrito

In the mean time, we should start using react-testing-library from now on and remove the usage of Enzyme from our own projects asap.