### PR TITLE
[Deprecated] Enzyme

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,24 +1,16 @@
-import { mount } from 'enzyme'
+import { render } from 'react-dom'
 
-const mountUsingEnzyme = Component => {
-  const componentMounted = mount(Component)
+const mount = component => {
+  const rootNode = document.body.appendChild(document.createElement('div'))
 
-  componentMounted.asyncFind = selector => {
-    return new Promise(resolve => {
-      setImmediate(() => {
-        componentMounted.update()
+  render(component, rootNode)
 
-        resolve(componentMounted.find(selector))
-      })
-    })
-  }
-
-  return componentMounted
+  return rootNode
 }
 
 let config = {
   defaultHost: '',
-  mount: mountUsingEnzyme,
+  mount,
   defaultStore: {},
   reducers: null,
 }

--- a/tests/components.mock.js
+++ b/tests/components.mock.js
@@ -1,31 +1,33 @@
 import React, { Component, Fragment, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useSelector } from 'react-redux'
 
-export const MyComponent = props => <div>Foo</div>
+export const MyComponent = () => <div>Foo</div>
 
-export class MyAsyncComponent extends Component {
-  state = {
-    isReady: false,
-  }
-
-  async componentDidMount() {
-    const myData = await this.getResource()
-
-    if (!myData) {
-      return
+export const MyComponentWithProps = props => (
+  <div>
+    { props &&
+      Object.entries(props).map(prop => prop)
     }
+  </div>
+)
 
-    this.setState({ isReady: true })
+export const MyComponentWithPortal = ({ children }) => (
+  createPortal(children, document.getElementById('portal-root-id'))
+)
+
+export const MyComponentWithStore = () => {
+  const session = useSelector(state => state.session)
+
+  if (!session || !session.isAuth) {
+    return <p>Please, login</p>
   }
 
-  getResource() {
-    return Promise.resolve('my data')
-  }
+  return <p>Hello { session.user }</p>
+}
 
-  render() {
-    if (!this.state.isReady) { return null }
-
-    return <div data-test="title">I am ready</div>
-  }
+export const MyComponentWithRouter = ({ match }) => {
+  return <p>Current route: "{ match.url }"</p>
 }
 
 export class MyComponentMakingHttpCalls extends Component {
@@ -60,8 +62,8 @@ export class MyComponentMakingHttpCalls extends Component {
   }
 
   render = () => (
-    <div data-test="quantity" onClick={ this.saveQuantity }>
-      { this.state.quantity }
+    <div data-testid="quantity" onClick={ this.saveQuantity }>
+      <span>quantity: { this.state.quantity }</span>
       { this.state.isSaved && <i aria-label="quantity saved" /> }
     </div>
   )

--- a/tests/wrap.test.js
+++ b/tests/wrap.test.js
@@ -1,11 +1,12 @@
-import { render } from 'react-dom'
-import { render as renderUsingTestingLibrary, wait } from '@testing-library/react'
-import { combineReducers } from 'redux'
+import { render, wait, fireEvent } from '@testing-library/react'
 import { wrap, configureMocks } from '../src/index'
 import { getMocksConfig } from '../src/config'
 import {
   MyComponent,
-  MyAsyncComponent,
+  MyComponentWithProps,
+  MyComponentWithPortal,
+  MyComponentWithStore,
+  MyComponentWithRouter,
   MyComponentMakingHttpCalls,
   MyComponentRepeatingHttpCalls,
 } from './components.mock'
@@ -21,43 +22,36 @@ function resetMocksConfig() {
 describe('burrito', () => {
   afterEach(resetMocksConfig)
 
-  it('should expose a way to find elements asynchronously', async () => {
-    const myAsyncComponent = wrap(MyAsyncComponent).mount()
-
-    expect(myAsyncComponent).toHaveProperty('asyncFind')
-    const title = await myAsyncComponent.asyncFind('[data-test="title"]')
-    expect(title.exists()).toBeTruthy()
-  })
-
   it('should have props', () => {
+    configureMocks({ mount: render })
     const props = { foo: 'bar' }
-    const myComponentWithProps = wrap(MyComponent).withProps(props).mount()
-    const expectedProps = expect.objectContaining(props)
 
-    expect(myComponentWithProps.props()).toEqual(expectedProps)
+    const { container } = wrap(MyComponentWithProps).withProps(props).mount()
+
+    expect(container).toHaveTextContent(props.foo)
   })
 
   it('should have an element where to place a portal', () => {
-    const portalRootId = 'portal-root'
+    configureMocks({ mount: render })
+    const childrenText = 'I am a portal'
+    const portalRootId = 'portal-root-id'
+    const props = { children: childrenText }
 
-    wrap(MyComponent).withPortalAt(portalRootId).mount()
-    const portalRoot = document.querySelector(`#${ portalRootId }`)
+    wrap(MyComponentWithPortal).withProps(props).withPortalAt(portalRootId).mount()
 
-    expect(portalRoot).toBeDefined()
+    expect(document.body).toHaveTextContent(childrenText)
   })
 
   it('should have default routing', () => {
-    const myComponentWithRouter = wrap(MyComponent).withRouter().mount()
-    const expectedProps = expect.objectContaining({
-      history: expect.anything(),
-      location: expect.anything(),
-      match: expect.anything(),
-    })
+    configureMocks({ mount: render })
 
-    expect(myComponentWithRouter.find(MyComponent).props()).toEqual(expectedProps)
+    const { container } = wrap(MyComponentWithRouter).withRouter().mount()
+
+    expect(container).toHaveTextContent('Current route: "/"')
   })
 
   it('should have current route if specified', () => {
+    configureMocks({ mount: render })
     const routing = {
       currentRoute: {
         exact: true,
@@ -66,50 +60,30 @@ describe('burrito', () => {
       },
     }
 
-    const myComponentWithRouter = wrap(MyComponent).withRouter(routing).mount()
-    const expectedProps = expect.objectContaining({
-      history: expect.anything(),
-      location: expect.anything(),
-      match: expect.objectContaining({
-        isExact: routing.currentRoute.exact,
-        params: {
-          myParam: '5',
-        },
-        path: routing.currentRoute.path,
-        url: routing.currentRoute.route,
-      }),
-    })
+    const { container } = wrap(MyComponentWithRouter).withRouter(routing).mount()
 
-    expect(myComponentWithRouter.find(MyComponent).props()).toEqual(expectedProps)
+    expect(container).toHaveTextContent('Current route: "/my/path/with/param/5"')
   })
 
   it('should have default store', () => {
-    const products = (state = 10, action) => state
-    const session = (state = { isAuth: false }, action) => state
-    const reducers = combineReducers({ products, session })
-    const defaultStore = { session: { isAuth: true } }
-    const expectedStoreState = { ...reducers(), ...defaultStore }
+    const session = (state = { isAuth: false }) => state
+    const defaultStore = { session: { isAuth: true, user: 'Anonymous' } }
 
-    configureMocks({ defaultStore, reducers })
-    const myComponentWithStore = wrap(MyComponent).withStore().mount()
+    configureMocks({ defaultStore, reducers: session, mount: render })
+    const { container } = wrap(MyComponentWithStore).withStore().mount()
 
-    const storeState = myComponentWithStore.props().store.getState()
-    expect(storeState).toEqual(expectedStoreState)
+    expect(container).toHaveTextContent('Hello Anonymous')
   })
 
   it('should have a initial store state if specified', () => {
-    const store = { products: 50 }
-    const products = (state = 10, action) => state
-    const session = (state = { isAuth: false }, action) => state
-    const reducers = combineReducers({ products, session })
+    const session = (state = { isAuth: false }) => state
     const defaultStore = { session: { isAuth: true } }
-    const expectedStoreState = { ...defaultStore, ...store }
+    const store = { session: { isAuth: true, user: 'Spiderman' } }
 
-    configureMocks({ defaultStore, reducers })
-    const myComponentWithStore = wrap(MyComponent).withStore(store).mount()
+    configureMocks({ defaultStore, reducers: session, mount: render })
+    const { container } = wrap(MyComponentWithStore).withStore(store).mount()
 
-    const storeState = myComponentWithStore.props().store.getState()
-    expect(storeState).toEqual(expectedStoreState)
+    expect(container).toHaveTextContent('Hello Spiderman')
   })
 
   it('should throw if it does not have any reducer', () => {
@@ -122,44 +96,51 @@ describe('burrito', () => {
   })
 
   it('should have mocks', async () => {
-    const myComponentMakingHttpCalls = wrap(MyComponentMakingHttpCalls)
+    configureMocks({ mount: render })
+    const { container } = wrap(MyComponentMakingHttpCalls)
       .withMocks({ method: 'get', path: '/path/to/get/quantity/', host: 'my-host', responseBody: '15', status: 200 })
       .mount()
 
-    const quantity = (await myComponentMakingHttpCalls.asyncFind('[data-test="quantity"]')).text()
-    expect(quantity).toBe('15')
+      expect(container).toHaveTextContent('quantity: 0')
+
+      await wait(() => {
+        expect(container).toHaveTextContent('quantity: 15')
+      })
   })
 
   it('should have default mocks', async () => {
-    configureMocks({ defaultHost: 'my-host' })
-    const myComponentMakingHttpCalls = wrap(MyComponentMakingHttpCalls)
+    configureMocks({ defaultHost: 'my-host', mount: render })
+    const { container } = wrap(MyComponentMakingHttpCalls)
       .withMocks({ path: '/path/to/get/quantity/', responseBody: '15' })
       .mount()
 
-    const quantity = (await myComponentMakingHttpCalls.asyncFind('[data-test="quantity"]')).text()
-    expect(quantity).toBe('15')
+    expect(container).toHaveTextContent('quantity: 0')
+
+    await wait(() => {
+      expect(container).toHaveTextContent('quantity: 15')
+    })
   })
 
   it('should try to match the request body as well', async () => {
-    configureMocks({ defaultHost: 'my-host' })
+    configureMocks({ defaultHost: 'my-host', mount: render })
     const quantity = '15'
-    const myComponentMakingHttpCalls = wrap(MyComponentMakingHttpCalls)
+    const { getByText, getByLabelText, queryByLabelText, getByTestId } = wrap(MyComponentMakingHttpCalls)
       .withMocks([
         { path: '/path/to/get/quantity/', responseBody: quantity },
         { method: 'post', path: '/path/to/save/quantity/', requestBody: { quantity } },
       ])
       .mount()
 
-    const successIconBeforeSave = (await myComponentMakingHttpCalls.asyncFind('[aria-label="quantity saved"]'))
-    expect(successIconBeforeSave).toHaveLength(0)
-    myComponentMakingHttpCalls.find('[data-test="quantity"]').simulate('click')
+    await wait(() => getByText('quantity: 15'))
+    expect(queryByLabelText('quantity saved')).not.toBeInTheDocument()
 
-    const successIconAfterSave = (await myComponentMakingHttpCalls.asyncFind('[aria-label="quantity saved"]'))
-    expect(successIconAfterSave).toHaveLength(1)
+    fireEvent.click(getByTestId('quantity'))
+
+    await wait(() => expect(getByLabelText('quantity saved')).toBeInTheDocument())
   })
 
   it('should mock different responses given the same request', async () => {
-    configureMocks({ defaultHost: 'my-host', mount: renderUsingTestingLibrary })
+    configureMocks({ defaultHost: 'my-host', mount: render })
 
     const productsBeforeRefreshing = ['tomato', 'orange']
     const productsAfterRefreshing = ['tomato', 'orange', 'apple']
@@ -185,7 +166,7 @@ describe('burrito', () => {
   })
 
   it('should not have enough responses specified', async () => {
-    configureMocks({ defaultHost: 'my-host', mount: renderUsingTestingLibrary })
+    configureMocks({ defaultHost: 'my-host', mount: render })
     console.warn = jest.fn()
 
     const products = ['tomato', 'orange']
@@ -211,30 +192,20 @@ describe('burrito', () => {
     )
   })
 
-  it('should use Enzyme by default', () => {
+  it('should use the default mount', () => {
     const expectedText = 'Foo'
-    const mountedWithEnzymeComponent = wrap(MyComponent).mount()
 
-    const textFoundByUsingEnzymeAPI = mountedWithEnzymeComponent.text()
+    const { textContent } = wrap(MyComponent).mount()
 
-    expect(textFoundByUsingEnzymeAPI).toBe(expectedText)
+    expect(textContent).toBe(expectedText)
   })
 
   it('should use a custom mount', () => {
-    function mountUsingNativeBrowserAPI(component) {
-      const rootNode = document.body.appendChild(document.createElement('div'))
-
-      render(component, rootNode)
-
-      return rootNode
-    }
-
-    configureMocks({ mount: mountUsingNativeBrowserAPI })
+    configureMocks({ mount: render })
     const expectedText = 'Foo'
-    const mountedWithNativeBrowserAPIComponent = wrap(MyComponent).mount()
 
-    const textFoundByUsingNativeBrowserAPI = mountedWithNativeBrowserAPIComponent.textContent
+    const { container } = wrap(MyComponent).mount()
 
-    expect(textFoundByUsingNativeBrowserAPI).toBe(expectedText)
+    expect(container).toHaveTextContent(expectedText)
   })
 })


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Deprecate Enzyme - Remove every usage of Enzyme. The default mount will use the react render.
Added a few mocked components in order to improve some of the tests we had to check the portals, routing and store.

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to get rid of Enzyme as dependecy and for that reason we need to stop using