### PR TITLE
[Fixed] Portal root must be unique

### DIFF
--- a/src/wrap.js
+++ b/src/wrap.js
@@ -49,6 +49,8 @@ const wrap = options => {
 }
 
 function setupPortal(portalRootId) {
+  if (document.getElementById(portalRootId)) { return }
+
   const portalRoot = document.createElement('div')
   portalRoot.setAttribute('id', portalRootId)
   document.body.appendChild(portalRoot)

--- a/tests/wrap.test.js
+++ b/tests/wrap.test.js
@@ -1,12 +1,22 @@
-import { render } from '@testing-library/react'
+import { render, cleanup } from '@testing-library/react'
 import { wrap, configureMocks } from '../src/index'
 import { getMocksConfig } from '../src/config'
 import { MyComponent, MyComponentWithProps, MyComponentWithPortal } from './components.mock'
+
+const portalRootId = 'portal-root-id'
+
+const removePortals = portalRootId => {
+  const portal = document.getElementById(portalRootId)
+  if (!portal) { return }
+  document.body.removeChild(portal)
+}
 
 const defaultMocksConfig = getMocksConfig()
 
 function resetMocksConfig() {
   configureMocks(defaultMocksConfig)
+  cleanup()
+  removePortals(portalRootId)
 }
 
 afterEach(resetMocksConfig)
@@ -21,14 +31,23 @@ it('should have props', () => {
 })
 
 it('should have an element where to place a portal', () => {
-  configureMocks({ mount: render })
   const childrenText = 'I am a portal'
-  const portalRootId = 'portal-root-id'
   const props = { children: childrenText }
 
   wrap(MyComponentWithPortal).withProps(props).withPortalAt(portalRootId).mount()
 
   expect(document.body).toHaveTextContent(childrenText)
+})
+
+it('should have unique portals', () => {
+  configureMocks({ mount: render })
+  const childrenText = 'I am a portal'
+  const props = { children: childrenText }
+
+  wrap(MyComponentWithPortal).withProps(props).withPortalAt(portalRootId).mount()
+  wrap(MyComponentWithPortal).withProps(props).withPortalAt(portalRootId).mount()
+
+  expect(document.querySelectorAll(`#${ portalRootId }`)).toHaveLength(1)
 })
 
 it('should use the default mount', () => {


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Portal root must be unique - Render a portal root only if it doesn't exist yet.

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It was causing a given portal root to be rendered multiple times.