### PR TITLE
[Fixed] Warnings containing objects should be stringified properly

### DIFF
--- a/src/notUtilizedResponses.js
+++ b/src/notUtilizedResponses.js
@@ -38,7 +38,7 @@ return `MULTIPLE RESPONSES:
 `
   }
 
-  return `RESPONSE BODY: ${ greenBright(responseBody) }`
+  return `RESPONSE BODY: ${ greenBright(JSON.stringify(responseBody)) }`
 }
 
 const multipleResponseIsNotUsed = response => !response.hasBeenReturned

--- a/tests/notUtilizedResponses.test.js
+++ b/tests/notUtilizedResponses.test.js
@@ -16,7 +16,7 @@ it('should warn when there are responses not being used', async () => {
   wrap(MyComponentMakingHttpCalls)
     .withMocks([
       { path: '/path/to/get/quantity/', responseBody: '15' },
-      { path: '/path/to/endpoint/not/being/used/', responseBody: 'I am not being used' },
+      { path: '/path/to/endpoint/not/being/used/', responseBody: { value: 'I am not being used' } },
     ])
     .mount()
 


### PR DESCRIPTION
## :camera: Screenshots/Gif
Before | After
---|---
![image](https://user-images.githubusercontent.com/2057033/74147048-ba738580-4c02-11ea-81b9-4c4b8c10be39.png) | ![image](https://user-images.githubusercontent.com/2057033/74146963-85ffc980-4c02-11ea-8fd3-e97a1c7f40d5.png)

## :tophat: What?
<!--- Describe your changes in detail -->
Warnings containing objects should be stringified properly

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Response body containing objects can't be read