### PR TITLE
[Changed] Rename getNotUtilizedRespones to highlightNotUtilizedResponses

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 export { wrap } from './wrap'
 export { mockFetch } from './mockFetch'
 export { configureMocks } from './config'
-export { getNotUtilizedResponses } from './notUtilizedResponses'
+export { highlightNotUtilizedResponses } from './notUtilizedResponses'

--- a/src/mockFetch.js
+++ b/src/mockFetch.js
@@ -1,7 +1,7 @@
 import deepEqual from 'deep-equal'
 import { white, redBright, greenBright } from 'chalk'
 import { getMocksConfig } from './config'
-import { saveListOfResponses, addResponseAsUtilized, getNotUtilizedResponses } from './notUtilizedResponses'
+import { saveListOfResponses, addResponseAsUtilized } from './notUtilizedResponses'
 
 global.fetch = jest.fn()
 
@@ -86,4 +86,4 @@ ${ white.bold.bgRed('burrito') } ${ redBright.bold('all responses have been retu
   })
 }
 
-export { mockFetch, getNotUtilizedResponses }
+export { mockFetch }

--- a/src/notUtilizedResponses.js
+++ b/src/notUtilizedResponses.js
@@ -6,12 +6,8 @@ const saveListOfResponses = listOfResponses => mockedResponses = [ ...listOfResp
 let utilizedResponses = []
 const addResponseAsUtilized = utilizedResponse => utilizedResponses = [ ...utilizedResponses, utilizedResponse ]
 
-const getNotUtilizedResponses = () => {
-  const notUtilizedResponses = mockedResponses.filter(response => {
-    const hasNotUtilzedResponses = !utilizedResponses.includes(response)
-    const multiplResponseNotFullyReturned = response.multipleResponses && response.multipleResponses.some(multipleResponseIsNotUsed)
-    return hasNotUtilzedResponses || multiplResponseNotFullyReturned
-  })
+const highlightNotUtilizedResponses = () => {
+  const notUtilizedResponses = mockedResponses.filter(getNotUtilizedResponses)
 
   const allResponsesAreBeingUtilized = notUtilizedResponses.length === 0
 
@@ -43,4 +39,12 @@ return `MULTIPLE RESPONSES:
 
 const multipleResponseIsNotUsed = response => !response.hasBeenReturned
 
-export { saveListOfResponses, addResponseAsUtilized, getNotUtilizedResponses }
+const getNotUtilizedResponses = response => {
+  const hasNotUtilzedResponses = !utilizedResponses.includes(response)
+  const multiplResponseNotFullyReturned = response.multipleResponses &&
+    response.multipleResponses.some(multipleResponseIsNotUsed)
+
+  return hasNotUtilzedResponses || multiplResponseNotFullyReturned
+}
+
+export { saveListOfResponses, addResponseAsUtilized, highlightNotUtilizedResponses }

--- a/tests/notUtilizedResponses.test.js
+++ b/tests/notUtilizedResponses.test.js
@@ -1,5 +1,5 @@
 import { render, wait, cleanup } from '@testing-library/react'
-import { wrap, configureMocks, getNotUtilizedResponses } from '../src/index'
+import { wrap, configureMocks, highlightNotUtilizedResponses } from '../src/index'
 import { MyComponentMakingHttpCalls, MyComponentRepeatingHttpCalls } from './components.mock'
 import { refreshProductsList } from './helpers'
 
@@ -21,7 +21,7 @@ it('should warn when there are responses not being used', async () => {
     .mount()
 
   await wait(() => {
-    getNotUtilizedResponses()
+    highlightNotUtilizedResponses()
     expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('the following responses are not being used:'))
     expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('/path/to/endpoint/not/being/used/'))
     expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('get'))
@@ -43,7 +43,7 @@ it('should warn when there are multiple responses not being used', async () => {
     .mount()
 
   await wait(() => {
-    getNotUtilizedResponses()
+    highlightNotUtilizedResponses()
     expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('the following responses are not being used:'))
     expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('/path/to/endpoint/not/being/used/'))
     expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('get'))
@@ -67,7 +67,7 @@ it('should warn when at least one of the multiple responses are not being used',
   refreshProductsList(container)
 
   await wait(() => {
-    getNotUtilizedResponses()
+    highlightNotUtilizedResponses()
     expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('the following responses are not being used:'))
     expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('/path/to/get/products/'))
     expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('get'))
@@ -84,7 +84,7 @@ it('should not warn when all the responses are being used', async () => {
     .mount()
 
   await wait(() => {
-    getNotUtilizedResponses()
+    highlightNotUtilizedResponses()
     expect(consoleWarn).not.toHaveBeenCalled()
   })
 })
@@ -102,7 +102,7 @@ it('should not warn when all the multiple responses are being used', async () =>
   refreshProductsList(container)
 
   await wait(() => {
-    getNotUtilizedResponses()
+    highlightNotUtilizedResponses()
     expect(consoleWarn).not.toHaveBeenCalled()
   })
 })

--- a/tests/withMocks.test.js
+++ b/tests/withMocks.test.js
@@ -1,5 +1,5 @@
 import { render, wait, fireEvent, cleanup } from '@testing-library/react'
-import { wrap, configureMocks, getNotUtilizedResponses } from '../src/index'
+import { wrap, configureMocks, highlightNotUtilizedResponses } from '../src/index'
 import { MyComponentMakingHttpCalls, MyComponentRepeatingHttpCalls, } from './components.mock'
 import { refreshProductsList, getTableRowsText } from './helpers'
 import { getMocksConfig } from '../src/config'
@@ -10,7 +10,7 @@ function resetMocksConfig() {
   cleanup()
   configureMocks(defaultMocksConfig)
   jest.restoreAllMocks()
-  getNotUtilizedResponses()
+  highlightNotUtilizedResponses()
 }
 
 afterEach(resetMocksConfig)


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Rename `getNotUtilizedRespones` to `highlightNotUtilizedResponses`

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It tells more about what it actually does

Suggestions are welcome