### PR TITLE
[Removed] configureMocks function in favor of configure

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -13,13 +13,13 @@ let config = {
   mount,
 }
 
-function configureMocks(newConfig) {
+function configure(newConfig) {
   config = {
     ...config,
     ...newConfig,
   }
 }
 
-const getMocksConfig = () => ({ ...config })
+const getConfig = () => ({ ...config })
 
-export { configureMocks, getMocksConfig }
+export { configure, getConfig }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 export { wrap } from './wrap'
 export { mockFetch } from './mockFetch'
-export { configureMocks } from './config'
+export { configure } from './config'
 export { highlightNotUtilizedResponses } from './notUtilizedResponses'
 export { assertions } from './assertions'

--- a/src/mockFetch.js
+++ b/src/mockFetch.js
@@ -1,6 +1,6 @@
 import deepEqual from 'deep-equal'
 import { white, redBright, greenBright } from 'chalk'
-import { getMocksConfig } from './config'
+import { getConfig } from './config'
 import { saveListOfResponses, addResponseAsUtilized, resetUtilizedResponses, addRequestMissingResponse, resetRequestsMissingResponse } from './notUtilizedResponses'
 
 global.fetch = jest.fn()
@@ -23,7 +23,7 @@ const matchesRequestBody = (normalizedRequestBody, requestBody) => {
 const getRequestMatcher = (request, normalizedRequestBody) => ({
   method = 'get',
   path,
-  host = getMocksConfig().defaultHost,
+  host = getConfig().defaultHost,
   requestBody = null,
 }) => {
   const url = host + path

--- a/src/wrap.js
+++ b/src/wrap.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { mockFetch } from './mockFetch'
-import { getMocksConfig } from './config'
+import { getConfig } from './config'
 
 const wrap = options => {
   const isComponent = typeof options === 'function'
@@ -28,7 +28,7 @@ const wrap = options => {
       }
 
       if (hasPath) {
-        getMocksConfig().history.push(path)
+        getConfig().history.push(path)
       }
 
       return mount(options)
@@ -44,6 +44,6 @@ function setupPortal(portalRootId) {
   document.body.appendChild(portalRoot)
 }
 
-const mount = ({ Component, props }) => getMocksConfig().mount(<Component {...props} />)
+const mount = ({ Component, props }) => getConfig().mount(<Component {...props} />)
 
 export { wrap }

--- a/tests/appWithStore.test.js
+++ b/tests/appWithStore.test.js
@@ -1,4 +1,4 @@
-import { wrap, configureMocks as configure } from '../src'
+import { wrap, configure } from '../src'
 import { render , fireEvent } from '@testing-library/react'
 
 import { MyAppWithStore } from './components.mock'

--- a/tests/assertions.test.js
+++ b/tests/assertions.test.js
@@ -1,12 +1,12 @@
 import { render, wait, fireEvent } from '@testing-library/react'
 
-import { wrap, assertions, configureMocks } from '../src'
+import { wrap, assertions, configure } from '../src'
 import { MyComponentMakingHttpCalls, MyComponentRepeatingHttpCalls } from './components.mock'
 import { refreshProductsList, getTableRowsText } from './helpers'
 
 expect.extend(assertions)
 
-configureMocks({ defaultHost: 'my-host', mount: render })
+configure({ defaultHost: 'my-host', mount: render })
 
 afterEach(jest.restoreAllMocks)
 

--- a/tests/atPath.test.js
+++ b/tests/atPath.test.js
@@ -1,4 +1,4 @@
-import { wrap, configureMocks as configure } from '../src'
+import { wrap, configure } from '../src'
 import { render, fireEvent } from '@testing-library/react'
 
 import { MyAppWithRouting, history, myFakeModule } from './components.mock'

--- a/tests/notUtilizedResponses.test.js
+++ b/tests/notUtilizedResponses.test.js
@@ -1,9 +1,9 @@
 import { render, wait, cleanup } from '@testing-library/react'
-import { wrap, configureMocks, highlightNotUtilizedResponses } from '../src/index'
+import { wrap, configure, highlightNotUtilizedResponses } from '../src/index'
 import { MyComponentMakingHttpCalls, MyComponentRepeatingHttpCalls } from './components.mock'
 import { refreshProductsList } from './helpers'
 
-configureMocks({ defaultHost: 'my-host', mount: render })
+configure({ defaultHost: 'my-host', mount: render })
 
 afterEach(() => {
   cleanup()

--- a/tests/withMocks.test.js
+++ b/tests/withMocks.test.js
@@ -1,14 +1,14 @@
 import { render, wait, fireEvent, cleanup } from '@testing-library/react'
-import { wrap, configureMocks, highlightNotUtilizedResponses } from '../src/index'
+import { wrap, configure, highlightNotUtilizedResponses } from '../src/index'
 import { MyComponentMakingHttpCalls, MyComponentRepeatingHttpCalls, } from './components.mock'
 import { refreshProductsList, getTableRowsText } from './helpers'
-import { getMocksConfig } from '../src/config'
+import { getConfig } from '../src/config'
 
-const defaultMocksConfig = getMocksConfig()
+const defaultMocksConfig = getConfig()
 
 function resetMocksConfig() {
   cleanup()
-  configureMocks(defaultMocksConfig)
+  configure(defaultMocksConfig)
   jest.restoreAllMocks()
   highlightNotUtilizedResponses()
 }
@@ -16,7 +16,7 @@ function resetMocksConfig() {
 afterEach(resetMocksConfig)
 
 it('should have mocks', async () => {
-  configureMocks({ mount: render })
+  configure({ mount: render })
   const { container } = wrap(MyComponentMakingHttpCalls)
     .withMocks({ method: 'get', path: '/path/to/get/quantity/', host: 'my-host', responseBody: '15', status: 200 })
     .mount()
@@ -29,7 +29,7 @@ it('should have mocks', async () => {
 })
 
 it('should have default mocks', async () => {
-  configureMocks({ defaultHost: 'my-host', mount: render })
+  configure({ defaultHost: 'my-host', mount: render })
   const { container } = wrap(MyComponentMakingHttpCalls)
     .withMocks({ path: '/path/to/get/quantity/', responseBody: '15' })
     .mount()
@@ -42,7 +42,7 @@ it('should have default mocks', async () => {
 })
 
 it('should try to match the request body as well', async () => {
-  configureMocks({ defaultHost: 'my-host', mount: render })
+  configure({ defaultHost: 'my-host', mount: render })
   const quantity = '15'
   const { getByText, getByLabelText, queryByLabelText, getByTestId } = wrap(MyComponentMakingHttpCalls)
     .withMocks([
@@ -60,7 +60,7 @@ it('should try to match the request body as well', async () => {
 })
 
 it('should mock different responses given the same request', async () => {
-  configureMocks({ defaultHost: 'my-host', mount: render })
+  configure({ defaultHost: 'my-host', mount: render })
 
   const productsBeforeRefreshing = ['tomato', 'orange']
   const productsAfterRefreshing = ['tomato', 'orange', 'apple']
@@ -86,7 +86,7 @@ it('should mock different responses given the same request', async () => {
 })
 
 it('should not have enough responses specified', async () => {
-  configureMocks({ defaultHost: 'my-host', mount: render })
+  configure({ defaultHost: 'my-host', mount: render })
   console.warn = jest.fn()
 
   const products = ['tomato', 'orange']

--- a/tests/wrap.test.js
+++ b/tests/wrap.test.js
@@ -1,6 +1,6 @@
 import { render, cleanup } from '@testing-library/react'
-import { wrap, configureMocks } from '../src/index'
-import { getMocksConfig } from '../src/config'
+import { wrap, configure } from '../src/index'
+import { getConfig } from '../src/config'
 import { MyComponent, MyComponentWithProps, MyComponentWithPortal } from './components.mock'
 
 const portalRootId = 'portal-root-id'
@@ -11,10 +11,10 @@ const removePortals = portalRootId => {
   document.body.removeChild(portal)
 }
 
-const defaultMocksConfig = getMocksConfig()
+const defaultMocksConfig = getConfig()
 
 function resetMocksConfig() {
-  configureMocks(defaultMocksConfig)
+  configure(defaultMocksConfig)
   cleanup()
   removePortals(portalRootId)
 }
@@ -22,7 +22,7 @@ function resetMocksConfig() {
 afterEach(resetMocksConfig)
 
 it('should have props', () => {
-  configureMocks({ mount: render })
+  configure({ mount: render })
   const props = { foo: 'bar' }
 
   const { container } = wrap(MyComponentWithProps).withProps(props).mount()
@@ -40,7 +40,7 @@ it('should have an element where to place a portal', () => {
 })
 
 it('should have unique portals', () => {
-  configureMocks({ mount: render })
+  configure({ mount: render })
   const childrenText = 'I am a portal'
   const props = { children: childrenText }
 
@@ -58,7 +58,7 @@ it('should use the default mount', () => {
 })
 
 it('should use a custom mount', () => {
-  configureMocks({ mount: render })
+  configure({ mount: render })
   const expectedText = 'Foo'
 
   const { container } = wrap(MyComponent).mount()


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Deprecate & remove `configureMocks` function in favor of `configure`

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It started as a configuration entry for the mocks but ended being the configuration entry of the whole burrito