### PR TITLE
[Added] Ignore query params by default unless using catchParams property

### DIFF
--- a/src/mockFetch.js
+++ b/src/mockFetch.js
@@ -18,9 +18,8 @@ const matchesRequestMethod = (request, method) => request.method.toLowerCase() =
 const matchesRequestUrl = (request, url, catchParams) => {
   if (catchParams) return request.url === url
 
-  const { pathname: requestURL } = new URL(request.url)
-  const { pathname: responseURL } = new URL(url)
-  return requestURL === responseURL
+  const urlWithoutQueryParams = request.url.split('?')[0]
+  return urlWithoutQueryParams === url
 }
 const matchesRequestBody = (normalizedRequestBody, requestBody) => {
   return deepEqual(normalizedRequestBody, requestBody)

--- a/tests/assertions.test.js
+++ b/tests/assertions.test.js
@@ -6,7 +6,7 @@ import { refreshProductsList, getTableRowsText } from './helpers'
 
 expect.extend(assertions)
 
-configure({ defaultHost: 'http://my-host.com', mount: render })
+configure({ defaultHost: 'my-host', mount: render })
 
 afterEach(jest.restoreAllMocks)
 
@@ -102,7 +102,7 @@ it('should not match network requests when missing responses for a given request
     expect(message()).toContain('  Object {')
     expect(message()).toContain('    "method": "get",')
     expect(message()).toContain('    "requestBody": null,')
-    expect(message()).toContain('    "url": "http://my-host.com/path/to/get/quantity/",')
+    expect(message()).toContain('    "url": "my-host/path/to/get/quantity/",')
     expect(message()).toContain('  },')
     expect(responses).not.toMatchNetworkRequests()
   })
@@ -133,7 +133,7 @@ it('should not match network requests when all multiple responses have been retu
     expect(message()).toContain('  Object {')
     expect(message()).toContain('    "method": "get",')
     expect(message()).toContain('    "requestBody": null,')
-    expect(message()).toContain('    "url": "http://my-host.com/path/to/get/products/",')
+    expect(message()).toContain('    "url": "my-host/path/to/get/products/",')
     expect(message()).toContain('  },')
     expect(responses).not.toMatchNetworkRequests()
   })

--- a/tests/components.mock.js
+++ b/tests/components.mock.js
@@ -27,7 +27,7 @@ export class MyComponentMakingHttpCalls extends Component {
   }
 
   componentDidMount = async () => {
-    const request = new Request('http://my-host.com/path/to/get/quantity/')
+    const request = new Request('my-host/path/to/get/quantity/')
     const quantityResponse = await fetch(request)
     if (!quantityResponse) return
     if (quantityResponse.status !== 200) {
@@ -40,7 +40,7 @@ export class MyComponentMakingHttpCalls extends Component {
   }
 
   saveQuantity = async () => {
-    const request = new Request('http://my-host.com/path/to/save/quantity/', {
+    const request = new Request('my-host/path/to/save/quantity/', {
       method: 'POST',
       body: JSON.stringify({ quantity: this.state.quantity }),
     })
@@ -64,7 +64,7 @@ export const MyComponentRepeatingHttpCalls = () => {
   const [ products, setProducts ] = useState([])
 
   const fetchProducts = async () => {
-    const productsRequest = new Request('http://my-host.com/path/to/get/products/')
+    const productsRequest = new Request('my-host/path/to/get/products/')
     try {
       const productsResponse = await fetch(productsRequest)
       const products = await productsResponse.json()
@@ -176,7 +176,7 @@ export const MyComponentMakingHttpCallsWithQueryParams = () => {
   }, [])
 
   const getQuantity = async () => {
-    const request = new Request('http://my-host.com/path/with/query/params/?myAwesome=param')
+    const request = new Request('/path/with/query/params/?myAwesome=param')
     const response = await fetch(request)
     if (!response) return
     const quantity = await response.json()

--- a/tests/notUtilizedResponses.test.js
+++ b/tests/notUtilizedResponses.test.js
@@ -1,13 +1,9 @@
 import { render, wait, cleanup } from '@testing-library/react'
 import { wrap, configure, highlightNotUtilizedResponses } from '../src/index'
-import {
-  MyComponentMakingHttpCalls,
-  MyComponentRepeatingHttpCalls,
-  MyComponentMakingHttpCallsWithQueryParams,
-} from './components.mock'
+import { MyComponentMakingHttpCalls, MyComponentRepeatingHttpCalls } from './components.mock'
 import { refreshProductsList } from './helpers'
 
-configure({ defaultHost: 'http://my-host.com', mount: render })
+configure({ defaultHost: 'my-host', mount: render })
 
 afterEach(() => {
   cleanup()
@@ -28,26 +24,6 @@ it('should warn when there are responses not being used', async () => {
     highlightNotUtilizedResponses()
     expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('the following responses are not being used:'))
     expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('/path/to/endpoint/not/being/used/'))
-    expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('get'))
-    expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('I am not being used'))
-  })
-})
-
-it('should warn when there are responses with query params not being used', async () => {
-  const consoleWarn = jest.spyOn(console, 'warn').mockImplementation()
-
-  wrap(MyComponentMakingHttpCallsWithQueryParams)
-    .withMocks({
-      path: '/path/with/query/params/?notUsedParam=param',
-      responseBody: 'I am not being used',
-      catchParams: true,
-    })
-    .mount()
-
-  await wait(() => {
-    highlightNotUtilizedResponses()
-    expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('the following responses are not being used:'))
-    expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('/path/with/query/params/?notUsedParam=param'))
     expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('get'))
     expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('I am not being used'))
   })

--- a/tests/withMocks.test.js
+++ b/tests/withMocks.test.js
@@ -22,7 +22,7 @@ afterEach(resetMocksConfig)
 it('should have mocks', async () => {
   configure({ mount: render })
   const { container } = wrap(MyComponentMakingHttpCalls)
-    .withMocks({ method: 'get', path: '/path/to/get/quantity/', host: 'http://my-host.com', responseBody: '15', status: 200 })
+    .withMocks({ method: 'get', path: '/path/to/get/quantity/', host: 'my-host', responseBody: '15', status: 200 })
     .mount()
 
     expect(container).toHaveTextContent('quantity: 0')
@@ -33,7 +33,7 @@ it('should have mocks', async () => {
 })
 
 it('should have default mocks', async () => {
-  configure({ defaultHost: 'http://my-host.com', mount: render })
+  configure({ defaultHost: 'my-host', mount: render })
   const { container } = wrap(MyComponentMakingHttpCalls)
     .withMocks({ path: '/path/to/get/quantity/', responseBody: '15' })
     .mount()
@@ -46,7 +46,7 @@ it('should have default mocks', async () => {
 })
 
 it('should try to match the request body as well', async () => {
-  configure({ defaultHost: 'http://my-host.com', mount: render })
+  configure({ defaultHost: 'my-host', mount: render })
   const quantity = '15'
   const { getByText, getByLabelText, queryByLabelText, getByTestId } = wrap(MyComponentMakingHttpCalls)
     .withMocks([
@@ -64,7 +64,7 @@ it('should try to match the request body as well', async () => {
 })
 
 it('should mock different responses given the same request', async () => {
-  configure({ defaultHost: 'http://my-host.com', mount: render })
+  configure({ defaultHost: 'my-host', mount: render })
 
   const productsBeforeRefreshing = ['tomato', 'orange']
   const productsAfterRefreshing = ['tomato', 'orange', 'apple']
@@ -90,7 +90,7 @@ it('should mock different responses given the same request', async () => {
 })
 
 it('should not have enough responses specified', async () => {
-  configure({ defaultHost: 'http://my-host.com', mount: render })
+  configure({ defaultHost: 'my-host', mount: render })
   console.warn = jest.fn()
 
   const products = ['tomato', 'orange']
@@ -117,7 +117,7 @@ it('should not have enough responses specified', async () => {
 })
 
 it('should ignore the query params by default', async () => {
-  configure({ mount: render, defaultHost: 'http://my-host.com' })
+  configure({ mount: render })
   const { container, findByText } = wrap(MyComponentMakingHttpCallsWithQueryParams)
     .withMocks({ path: '/path/with/query/params/', responseBody: '15' })
     .mount()
@@ -130,7 +130,7 @@ it('should ignore the query params by default', async () => {
 })
 
 it('should not ignore the query params when is specified', async () => {
-  configure({ mount: render, defaultHost: 'http://my-host.com' })
+  configure({ mount: render })
   const { container, findByText } = wrap(MyComponentMakingHttpCallsWithQueryParams)
     .withMocks({
         path: '/path/with/query/params/?myAwesome=param',


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Ignore query params by default unless using `withQueryParams`
## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As a default, we want to ignore the query params
## :white_check_mark: How has this been tested?
<!--- What types of test you are doing? -->
<!--- How do you know this is working properly? -->
Adding two different tests checking the request with query params and without query params.
## :speech_balloon: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->

The burrito API will be:
```
  wrap(MyComponent)
    .withMocks({
        path: '/path/with/query/params/?myAwesome=param',
        responseBody: '15',
        catchParams: true,
      })
    .mount()
```