### PR TITLE
[Added] Config to ignore query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,13 @@ wrap(MyComponent)
 ```
 `host`, `method` and `status` will be the same most of the cases, we don't want to specify them every single time.
 
-By default burrito 🌯 ignore the query params in your responses, but if you want to test it you can use the `catchParams` property in the request, like this:
+By default burrito 🌯 is testing the query params in your responses, but if you want to ignore it you must add the `handleQueryParams` param in the config and to test it you can use the `catchParams` property in the request, like this:
 
 ```
+import { configure } from '@mercadona/mo.library.burrito'
+
+configure({ handleQueryParams: true })
+
 wrap(MyComponentUsingQueryParams)
     .withMocks({
         path: '/path/with/query/params/?myAwesome=param',

--- a/src/mockFetch.js
+++ b/src/mockFetch.js
@@ -16,8 +16,8 @@ async function getNormalizedRequestBody(request) {
 
 const matchesRequestMethod = (request, method) => request.method.toLowerCase() === method
 const matchesRequestUrl = (request, url, catchParams) => {
-  const ignoreQueryParams = getConfig().ignoreQueryParams
-  if (!ignoreQueryParams || catchParams) return request.url === url
+  const handleQueryParams = getConfig().handleQueryParams
+  if (!handleQueryParams || catchParams) return request.url === url
 
   const urlWithoutQueryParams = request.url.split('?')[0]
   return urlWithoutQueryParams === url

--- a/tests/withMocks.test.js
+++ b/tests/withMocks.test.js
@@ -130,7 +130,7 @@ it('should not ignore the query params by default', async () => {
 })
 
 it('should ignore the query params when is configured', async () => {
-  configure({ mount: render, ignoreQueryParams: true })
+  configure({ mount: render, handleQueryParams: true })
   const { container, findByText } = wrap(MyComponentMakingHttpCallsWithQueryParams)
     .withMocks({ path: '/path/with/query/params/', responseBody: '15' })
     .mount()
@@ -143,7 +143,7 @@ it('should ignore the query params when is configured', async () => {
 })
 
 it('should not ignore the query params when is specified and it is configured', async () => {
-  configure({ mount: render, ignoreQueryParams: true  })
+  configure({ mount: render, handleQueryParams: true  })
   const { container, findByText } = wrap(MyComponentMakingHttpCallsWithQueryParams)
     .withMocks({
         path: '/path/with/query/params/?myAwesome=param',


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Added config to ignore query params
## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- As agreed we need an extra config to handle the query params:

```
import { configure } from '@mercadona/mo.library.burrito'

configure({ handleQueryParams: true }) 👈 👀 

wrap(MyComponentUsingQueryParams)
    .withMocks({
        path: '/path/with/query/params/?myAwesome=param',
        responseBody: '15',
        catchParams: true || false, 👈 👀 
      })
    .mount()
```