### PR TITLE
[Changed] differentiate request to same path by body

### DIFF
--- a/src/assertions/toHaveBeenFetchedWith.js
+++ b/src/assertions/toHaveBeenFetchedWith.js
@@ -4,21 +4,22 @@ const findRequestsByPath = path =>
 const getRequestsMethods = requests =>
   requests.map(request => request[1]?.method)
 
-const getRequestBody = requests => requests[0][1]?.body
+const getRequestsBodies = requests => requests.map(request => request[1]?.body)
 
 const methodDoesNotMatch = (expectedMethod, targetRequestsMethods) =>
   expectedMethod && !targetRequestsMethods.includes(expectedMethod)
 
-const isBodyDifferent = (optionsBody, targetRequestBody) => {
-  if (!optionsBody) return false
+const bodyDoesNotMatch = (expectedBody, targetRequestsBodies) => {
+  if (!expectedBody) return false
 
-  const targetRequestBodyEntries = Object.entries(targetRequestBody).sort()
-  const optionsBodyEntries = Object.entries(optionsBody).sort()
-
-  return (
-    JSON.stringify(targetRequestBodyEntries) !==
-    JSON.stringify(optionsBodyEntries)
+  const expectedBodyEntries = JSON.stringify(
+    Object.entries(expectedBody).sort(),
   )
+  const targetRequestBodyEntries = targetRequestsBodies.map(request =>
+    JSON.stringify(Object.entries(request).sort()),
+  )
+
+  return !targetRequestBodyEntries.includes(expectedBodyEntries)
 }
 
 const empty = requests => requests.length === 0
@@ -41,15 +42,16 @@ const toHaveBeenFetchedWith = (path, options) => {
     }
   }
 
-  const targetRequestBody = getRequestBody(targetRequests)
+  const targetRequestsBodies = getRequestsBodies(targetRequests)
+  const expectedBody = options?.body
 
-  if (isBodyDifferent(options?.body, targetRequestBody)) {
+  if (bodyDoesNotMatch(expectedBody, targetRequestsBodies)) {
     return {
       pass: false,
       message: () =>
         `Fetch body does not match, expected ${JSON.stringify(
           options.body,
-        )} received ${JSON.stringify(targetRequestBody)}`,
+        )} received ${JSON.stringify(targetRequestsBodies)}`,
     }
   }
 

--- a/tests/assertions/toHaveBeenFetchedWith.test.js
+++ b/tests/assertions/toHaveBeenFetchedWith.test.js
@@ -44,6 +44,25 @@ describe('toHaveBeenFetchedWith', () => {
       })
     })
 
+    it('should differentiate between to request to the same path but with different body', async () => {
+      const path = '/some/path/'
+      await fetch(path, { body: { name: 'some name' } })
+      await fetch(path, { body: { age: 32 } })
+
+      const { message } = assertions.toHaveBeenFetchedWith(path, {
+        body: {
+          age: 32,
+        },
+      })
+
+      expect(message()).toBeUndefined()
+      expect(path).toHaveBeenFetchedWith({
+        body: {
+          age: 32,
+        },
+      })
+    })
+
     it('should allow to specify the body elements in different order', async () => {
       const path = '/some/path/'
       await fetch(path, { body: { name: 'name', surname: 'surname' } })
@@ -77,7 +96,7 @@ describe('toHaveBeenFetchedWith', () => {
       expect(message()).toBe(
         `Fetch body does not match, expected ${JSON.stringify(
           expectedBody,
-        )} received ${JSON.stringify(receivedBody)}`,
+        )} received ${JSON.stringify([receivedBody])}`,
       )
       expect(path).not.toHaveBeenFetchedWith({
         body: expectedBody,


### PR DESCRIPTION
## :camera: Screenshots/Gif
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->

## :tophat: What?
<!--- Describe your changes in detail -->
Differentiate request to same path by body

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Should work this way
