### PR TITLE
[Changed] check expected path partially

### DIFF
--- a/src/assertions/toHaveBeenFetchedWith.js
+++ b/src/assertions/toHaveBeenFetchedWith.js
@@ -1,5 +1,5 @@
 const findRequestsByPath = path =>
-  fetch.mock.calls.filter(([mockedPath]) => mockedPath === path)
+  fetch.mock.calls.filter(([mockedPath]) => mockedPath.includes(path))
 
 const getRequestsMethods = requests =>
   requests.map(request => request[1]?.method)

--- a/tests/assertions/toHaveBeenFetchedWith.test.js
+++ b/tests/assertions/toHaveBeenFetchedWith.test.js
@@ -4,7 +4,7 @@ expect.extend(assertions)
 
 describe('toHaveBeenFetchedWith', () => {
   it('should check that the path has been called', async () => {
-    const path = '/some/path/'
+    const path = '//some-domain.com/some/path/'
     const expectedPath = '/some/path/'
     await fetch(path)
 
@@ -15,7 +15,7 @@ describe('toHaveBeenFetchedWith', () => {
   })
 
   it('should check that the path has not been called', async () => {
-    const path = '/some/path'
+    const path = '//some-domain.com/some/path/'
     const expectedPath = '/some/unknown'
 
     await fetch(path)
@@ -27,7 +27,7 @@ describe('toHaveBeenFetchedWith', () => {
 
   describe('request body', () => {
     it('should check that the path has been called with the supplied body', async () => {
-      const path = '/some/path/'
+      const path = '//some-domain.com/some/path/'
       await fetch(path, { body: { name: 'some name' } })
 
       const { message } = assertions.toHaveBeenFetchedWith(path, {
@@ -45,7 +45,7 @@ describe('toHaveBeenFetchedWith', () => {
     })
 
     it('should differentiate between to request to the same path but with different body', async () => {
-      const path = '/some/path/'
+      const path = '//some-domain.com/some/path/'
       await fetch(path, { body: { name: 'some name' } })
       await fetch(path, { body: { age: 32 } })
 
@@ -64,7 +64,7 @@ describe('toHaveBeenFetchedWith', () => {
     })
 
     it('should allow to specify the body elements in different order', async () => {
-      const path = '/some/path/'
+      const path = '//some-domain.com/some/path/'
       await fetch(path, { body: { name: 'name', surname: 'surname' } })
 
       const { message } = assertions.toHaveBeenFetchedWith(path, {
@@ -84,7 +84,7 @@ describe('toHaveBeenFetchedWith', () => {
     })
 
     it('should check that the path has not been called with the supplied body', async () => {
-      const path = '/some/path/'
+      const path = '//some-domain.com/some/path/'
       const expectedBody = { name: 'some name' }
       const receivedBody = { surname: 'some surname' }
 
@@ -104,7 +104,7 @@ describe('toHaveBeenFetchedWith', () => {
     })
 
     it('should allow to leave the body option empty', async () => {
-      const path = '/some/path/'
+      const path = '//some-domain.com/some/path/'
       await fetch(path, { body: { surname: 'some surname' } })
 
       const { message } = assertions.toHaveBeenFetchedWith(path)
@@ -116,7 +116,7 @@ describe('toHaveBeenFetchedWith', () => {
 
   describe('request method', () => {
     it('should check that the path has been called with the supplied method', async () => {
-      const path = '/some/path/'
+      const path = '//some-domain.com/some/path/'
       await fetch(path, { method: 'POST' })
 
       const { message } = assertions.toHaveBeenFetchedWith(path, {
@@ -130,7 +130,7 @@ describe('toHaveBeenFetchedWith', () => {
     })
 
     it('should differentiate between to request to the same path with different methods', async () => {
-      const path = '/some/path/'
+      const path = '//some-domain.com/some/path/'
       await fetch(path, { method: 'POST' })
       await fetch(path, { method: 'PUT' })
 
@@ -145,7 +145,7 @@ describe('toHaveBeenFetchedWith', () => {
     })
 
     it('should check that the path has not been called with the supplied method', async () => {
-      const path = '/some/path/'
+      const path = '//some-domain.com/some/path/'
       await fetch(path, { method: 'PUT' })
 
       const { message } = assertions.toHaveBeenFetchedWith(path, {
@@ -161,7 +161,7 @@ describe('toHaveBeenFetchedWith', () => {
     })
 
     it('should allow to leave the method empty', async () => {
-      const path = '/some/path/'
+      const path = '//some-domain.com/some/path/'
       await fetch(path, { method: 'POST' })
 
       const { message } = assertions.toHaveBeenFetchedWith(path)


### PR DESCRIPTION
## :camera: Screenshots/Gif
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->

## :tophat: What?
<!--- Describe your changes in detail -->
check expected path partially

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When using the new assertion in picking I have realised that the requests in the tests are done using a domain

`//picking.vlc1.sta.monline/logistics/api/v1_0/batch/variable-weight-operation/34343/finish/
`
So we need to check that the path contains the expected path instead of checking that the path match exactly.
