### PR TITLE
[Changed] should not throw already read TypeError

### DIFF
--- a/tests/assertions/toHaveBeenFetchedWith.test.js
+++ b/tests/assertions/toHaveBeenFetchedWith.test.js
@@ -48,6 +48,31 @@ describe('toHaveBeenFetchedWith', () => {
       })
     })
 
+    it('should not throw already read TypeError', async () => {
+      const path = '//some-domain.com/some/path/'
+      const request = new Request(path, {
+        method: 'POST',
+        body: JSON.stringify({ name: 'some name' }),
+        _bodyInit: JSON.stringify({ name: 'some name' }),
+      })
+
+      await fetch(request)
+      fetch.mock.calls[0][0].json()
+
+      const { message } = await assertions.toHaveBeenFetchedWith(path, {
+        body: {
+          name: 'some name',
+        },
+      })
+
+      expect(message()).toBeUndefined()
+      expect(path).toHaveBeenFetchedWith({
+        body: {
+          name: 'some name',
+        },
+      })
+    })
+
     it('should differentiate between to request to the same path but with different body', async () => {
       const path = '//some-domain.com/some/path/'
       const firstRequest = new Request(path, {


### PR DESCRIPTION
## :camera: Screenshots/Gif
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->

## :tophat: What?
<!--- Describe your changes in detail -->
Should not throw already read TypeError

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After testing the previous version in picking I was getting the error `TypeError: Already read`. Looks like its related to trying to use Body.json a second time. I want to try if this approach fixes the issue.

## Notes
I have also left another implementation in the function `getRequestsBodiesPatch` that it's using the _bodyInit field from the Request. I would also check if this is working in picking.

The problem here is that I couldn't make the test respond with a Request object with that field in burrito. 

Help is welcome to reproduce this!
