### PR TITLE
[Changed] use whatwg-fetch to reproduce projects set up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6119,6 +6119,11 @@
         "iconv-lite": "0.4.24"
       }
     },
+    "whatwg-fetch": {
+      "version": "3.5.0",
+      "resolved": "http://172.21.97.98/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
+    },
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "http://172.21.97.98/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   },
   "homepage": "https://github.com/mercadona/mo.library.burrito#readme",
   "dependencies": {
-    "deep-equal": "^1.0.1"
+    "deep-equal": "^1.0.1",
+    "whatwg-fetch": "^3.5.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",

--- a/src/assertions/toHaveBeenFetchedWith.js
+++ b/src/assertions/toHaveBeenFetchedWith.js
@@ -6,17 +6,9 @@ const getRequestsMethods = requests =>
 
 const getRequestsBodies = requests =>
   requests.map(request => {
-    const requestBody = request[0].body
-    if (!requestBody) return {}
-
-    return JSON.parse(Buffer.from(requestBody).toString())
-  })
-
-const getRequestsBodiesPatch = requests =>
-  requests.map(request => {
     if (!request[0]._bodyInit) return {}
 
-    JSON.parse(request[0]._bodyInit)
+    return JSON.parse(request[0]._bodyInit)
   })
 
 const methodDoesNotMatch = (expectedMethod, receivedRequestsMethods) =>

--- a/tests/assertions/toHaveBeenFetchedWith.test.js
+++ b/tests/assertions/toHaveBeenFetchedWith.test.js
@@ -1,4 +1,5 @@
 import { assertions } from '../../src'
+import 'whatwg-fetch'
 
 expect.extend(assertions)
 


### PR DESCRIPTION
## :camera: Screenshots/Gif
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->

## :tophat: What?
<!--- Describe your changes in detail -->
Use whatwg-fetch to reproduce projects set up

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There was a request object missmatch between picking and burrito.

Apparently burrito is using the Request returned by the fetch from node-fetch, and picking is using the Request returned by the fetch from whatwg-fetch.

This may be happening for all the project where we are checking the _bodyInit variable from the response. As far as I know, this is happening in picking and shop.
