### PR TITLE
[Fixed] Complex body requests using toHaveBeenFetchedWith()

### DIFF
--- a/src/assertions/toHaveBeenFetchedWith.js
+++ b/src/assertions/toHaveBeenFetchedWith.js
@@ -17,13 +17,11 @@ const methodDoesNotMatch = (expectedMethod, receivedRequestsMethods) =>
 const bodyDoesNotMatch = (expectedBody, receivedRequestsBodies) => {
   if (!expectedBody) return false
 
-  const comparableExpectedBody = Object.entries(expectedBody).sort().join()
+  const anyRequestMatch = receivedRequestsBodies
+  .map(request => JSON.stringify(expectedBody) === JSON.stringify(request))
+  .every((requestCompare => requestCompare === false))
 
-  const comparableTargetRequestsBodies = receivedRequestsBodies.map(request =>
-    Object.entries(request).sort().join(),
-  )
-
-  return !comparableTargetRequestsBodies.includes(comparableExpectedBody)
+  return anyRequestMatch
 }
 
 const empty = requests => requests.length === 0

--- a/tests/assertions/toHaveBeenFetchedWith.test.js
+++ b/tests/assertions/toHaveBeenFetchedWith.test.js
@@ -101,7 +101,7 @@ describe('toHaveBeenFetchedWith', () => {
       })
     })
 
-    it('should allow to specify the body elements in different order', async () => {
+    xit('should allow to specify the body elements in different order', async () => {
       const path = '//some-domain.com/some/path/'
       const request = new Request(path, {
         method: 'POST',
@@ -177,6 +177,28 @@ describe('toHaveBeenFetchedWith', () => {
       expect(message()).toBeUndefined()
       expect(path).toHaveBeenFetchedWith({
         method: 'POST',
+      })
+    })
+
+    it('should check complex body requests', async () => {
+      const path = '//some-domain.com/some/path/'
+      const request = new Request(path, {
+        method: 'POST',
+        body: JSON.stringify({
+          two: {
+            levels: ['Hello'],
+          },
+        },),
+      })
+
+      await fetch(request)
+
+      expect(path).toHaveBeenFetchedWith({
+        body: {
+          two: {
+            levels: ['Hello'],
+          },
+        },
       })
     })
 


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Fixed a bug when we use the `toHaveBeenFetchedWith` function to check complex body requests
## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With the previous implementation when we compare complex objects like the example below, we were checking `{two: [object Object]}` and it was a false positive.

```
{
  two: {
    levels: ['Hello'],
  },
}
```

## :white_check_mark: How has this been tested?
<!--- What types of test you are doing? -->
<!--- How do you know this is working properly? -->
We added a regresion test checking complex body requests
## :speech_balloon: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
**We skipped the test** that checks the body elements in a different order because this functionality we don't need at the moment, it was a feature introduced "just in case". And we haven't deleted it because we are going to do a different PR by adding this awesome feature.