### PR TITLE
[Changed] Slack channel to release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,11 @@ pipeline {
                         failingTarget: [methodCoverage: 0, conditionalCoverage: 0, statementCoverage: 0]     // optional, default is none
                     ])
                 }
-                slack.finalNotify('#logistics_events', tester.testStatuses())
+                if (env.TAG_NAME) {
+                    slack.finalNotify('#frontend', tester.testStatuses())
+                } else {
+                    slack.finalNotify('#logistics_events', tester.testStatuses())
+                }
             }
         }
     }


### PR DESCRIPTION
## :tophat: What?
Change slack channel to release

## :thinking: Why?
I think is better to do visibility to the new releases, I don't move all the notifications because I think the rest only add noise
