### PR TITLE
[Fixed] toHaveBeenFetchedWith so that body elements order doesnt matter

### DIFF
--- a/src/assertions/toHaveBeenFetchedWith.js
+++ b/src/assertions/toHaveBeenFetchedWith.js
@@ -1,3 +1,5 @@
+import deepEqual from 'deep-equal'
+
 const findRequestsByPath = path =>
   fetch.mock.calls.filter(call => call[0].url.includes(path))
 
@@ -18,8 +20,8 @@ const bodyDoesNotMatch = (expectedBody, receivedRequestsBodies) => {
   if (!expectedBody) return false
 
   const anyRequestMatch = receivedRequestsBodies
-  .map(request => JSON.stringify(expectedBody) === JSON.stringify(request))
-  .every((requestCompare => requestCompare === false))
+    .map(request => deepEqual(expectedBody, request))
+    .every(requestCompare => requestCompare === false)
 
   return anyRequestMatch
 }
@@ -30,7 +32,7 @@ const toHaveBeenFetchedWith = (path, options) => {
   const targetRequests = findRequestsByPath(path)
 
   if (empty(targetRequests)) {
-    return { pass: false, message: () => `${path} ain't got called` }
+    return { pass: false, message: () => `${ path } ain't got called` }
   }
 
   const receivedRequestsMethods = getRequestsMethods(targetRequests)
@@ -40,7 +42,7 @@ const toHaveBeenFetchedWith = (path, options) => {
     return {
       pass: false,
       message: () =>
-        `Fetch method does not match, expected ${expectedMethod} received ${receivedRequestsMethods}`,
+        `Fetch method does not match, expected ${ expectedMethod } received ${ receivedRequestsMethods }`,
     }
   }
 
@@ -51,9 +53,9 @@ const toHaveBeenFetchedWith = (path, options) => {
     return {
       pass: false,
       message: () =>
-        `Fetch body does not match, expected ${JSON.stringify(
+        `Fetch body does not match, expected ${ JSON.stringify(
           expectedBody,
-        )} received ${JSON.stringify(receivedRequestsBodies)}`,
+        ) } received ${ JSON.stringify(receivedRequestsBodies) }`,
     }
   }
 

--- a/tests/assertions/toHaveBeenFetchedWith.test.js
+++ b/tests/assertions/toHaveBeenFetchedWith.test.js
@@ -101,7 +101,7 @@ describe('toHaveBeenFetchedWith', () => {
       })
     })
 
-    xit('should allow to specify the body elements in different order', async () => {
+    it('should allow to specify the body elements in different order', async () => {
       const path = '//some-domain.com/some/path/'
       const request = new Request(path, {
         method: 'POST',
@@ -140,9 +140,9 @@ describe('toHaveBeenFetchedWith', () => {
       })
 
       expect(message()).toBe(
-        `Fetch body does not match, expected ${JSON.stringify(
+        `Fetch body does not match, expected ${ JSON.stringify(
           expectedBody,
-        )} received ${JSON.stringify([receivedBody])}`,
+        ) } received ${ JSON.stringify([receivedBody]) }`,
       )
       expect(path).not.toHaveBeenFetchedWith({
         body: expectedBody,
@@ -188,7 +188,7 @@ describe('toHaveBeenFetchedWith', () => {
           two: {
             levels: ['Hello'],
           },
-        },),
+        }),
       })
 
       await fetch(request)


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Fix `toHaveBeenFetchedWith` so that body elements order doesnt matter

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- There was a `xit` on an existing test, but the was failing.
- In order to be able to use `toHaveBeenFetchWith` passing a body with unordered properties. Order shouldn't matter.