### PR TITLE
[Removed] node-fetch dependency

### DIFF
--- a/config/polyfills.js
+++ b/config/polyfills.js
@@ -1,4 +1,5 @@
-import { Request, Headers } from 'node-fetch'
+import { Request, Headers } from 'whatwg-fetch'
 
 global.Request = Request
 global.Headers = Headers
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -4484,12 +4484,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "http://172.21.97.98/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-      "dev": true
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "http://172.21.97.98/node-int64/-/node-int64-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "babel-jest": "^24.8.0",
     "jest": "^24.1.0",
     "jest-junit": "^6.4.0",
-    "node-fetch": "^2.6.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.1",


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Remove `node-fetch` dependency

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Because we recently installed `whatwg-fetch` for other purposes but it also gives us what `node-fetch` does