### PR TITLE
[Removed] unnecessary import

### DIFF
--- a/tests/assertions/toHaveBeenFetchedWith.test.js
+++ b/tests/assertions/toHaveBeenFetchedWith.test.js
@@ -1,5 +1,4 @@
 import { assertions } from '../../src'
-import 'whatwg-fetch'
 
 expect.extend(assertions)
 


### PR DESCRIPTION
## :camera: Screenshots/Gif
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->

## :tophat: What?
<!--- Describe your changes in detail -->
Remove not needed `whatwg-fetch` import.

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Now this is being done in `config/polyfills.js`
