### PR TITLE
[Changed] Clean up test for toHaveBeenFetchedWith

### DIFF
--- a/tests/assertions/toHaveBeenFetchedWith.test.js
+++ b/tests/assertions/toHaveBeenFetchedWith.test.js
@@ -86,13 +86,11 @@ describe('toHaveBeenFetchedWith', () => {
       await fetch(firstRequest)
       await fetch(secondRequest)
 
-      const { message } = await assertions.toHaveBeenFetchedWith(path, {
+      expect(path).toHaveBeenFetchedWith({
         body: {
-          age: 32,
+          name: 'some name',
         },
       })
-
-      expect(message()).toBeUndefined()
       expect(path).toHaveBeenFetchedWith({
         body: {
           age: 32,


### PR DESCRIPTION
## :tophat: What?
Improved a test for the `toHaveBeenFetchedWith` matcher

## :thinking: Why?
We were checking some functionality and thought the test wasn't clear enough (before it was only asserting on `age: 32`, but not `name: "some name"`)