### PR TITLE
[Fixed] Delay implementation

### DIFF
--- a/src/mockNetwork.js
+++ b/src/mockNetwork.js
@@ -17,14 +17,18 @@ async function getNormalizedRequestBody(request) {
   }
 }
 
-const createResponse = async ({ responseBody, status = 200, headers, delay = 0 }) => {
+const createResponse = async ({ responseBody, status = 200, headers, delay }) => {
+  const response = {
+    json: () => Promise.resolve(responseBody),
+    status,
+    ok: status >= 200 && status <= 299,
+    headers: new Headers({ 'Content-Type': 'application/json', ...headers }),
+  }
+
+  if (!delay) return Promise.resolve(response)
+
   return new Promise(resolve => setTimeout(() => {
-    return resolve({
-      json: () => Promise.resolve(responseBody),
-      status,
-      ok: status >= 200 && status <= 299,
-      headers: new Headers({ 'Content-Type': 'application/json', ...headers }),
-    })
+    return resolve(response)
   }, delay))
 }
 

--- a/tests/withNetwork.test.js
+++ b/tests/withNetwork.test.js
@@ -45,7 +45,7 @@ it('should have network without responses', async () => {
   expect(await screen.findByText('SUCCESS')).toBeInTheDocument()
 })
 
-it('should not resolve a request with delay', async () => {
+it('should resolve a request with delay after the specified time', async () => {
   configure({ mount: render })
   jest.useFakeTimers()
   wrap(MyComponentWithNetwork)
@@ -76,4 +76,27 @@ it('should not resolve a request with delay', async () => {
 
   expect(screen.getByText('15')).toBeInTheDocument()
   jest.useRealTimers()
+})
+
+it('should resolve all the responses waiting for an unrelated text', async () => {
+  configure({ mount: render })
+  wrap(MyComponentWithNetwork)
+    .withNetwork([
+      {
+        path: '/path/',
+        host: 'my-host',
+        responseBody: 'SUCCESS',
+      },
+      {
+        path: '/path/with/response/',
+        host: 'my-host',
+        responseBody: '15',
+      },
+    ])
+    .mount()
+
+  await screen.findByText('MyComponentWithNetwork')
+
+  expect(screen.getByText('SUCCESS')).toBeInTheDocument()
+  expect(screen.getByText('15')).toBeInTheDocument()
 })


### PR DESCRIPTION
## :camera_flash: Screenshots/Gif/Videos
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->

## :tophat: What?
Fixed the delay implementation
<!--- Describe your changes in detail -->

## :thinking: Why?
It was causing an error for the tests that were awaiting for something not related with the responses
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
We have added a test that waits for a fixed text in the component and the asynchronous texts are also visible. If we want to change the implementation, we need to change that test to wait for an async text.
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->

## :speaking_head: Comments
- This is something that we can talk in the GM. I add it as a topic to the next GM.
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
