### PR TITLE
[Changed] `toHaveBeenFetchedWith` assertion error messages

### DIFF
--- a/src/assertions/toHaveBeenFetchedWith.js
+++ b/src/assertions/toHaveBeenFetchedWith.js
@@ -1,4 +1,32 @@
 import deepEqual from 'deep-equal'
+import { green, red } from 'chalk'
+
+const emptyErrorMessage = (path) => ({
+  pass: false,
+  message: () => `🌯 Burrito: ${path} ain't got called`,
+})
+
+const methodDoesNotMatchErrorMessage = (expected, received) => ({
+  pass: false,
+  message: () =>
+    `🌯 Burrito: Fetch method does not match, expected ${expected} received ${received}`,
+})
+
+const bodyDoesNotMatchErrorMessage = (expected, received) => ({
+  pass: false,
+  message: () =>
+    `🌯 Burrito: Fetch body does not match.
+Expected:
+${green(JSON.stringify(expected, null, ' '))}
+
+Received:
+${red(JSON.stringify(received, null, ' '))}`,
+})
+
+const successMessage = () => ({
+  pass: true,
+  message: () => undefined,
+})
 
 const findRequestsByPath = path =>
   fetch.mock.calls.filter(call => call[0].url.includes(path))
@@ -32,34 +60,24 @@ const toHaveBeenFetchedWith = (path, options) => {
   const targetRequests = findRequestsByPath(path)
 
   if (empty(targetRequests)) {
-    return { pass: false, message: () => `${ path } ain't got called` }
+    return emptyErrorMessage(path)
   }
 
   const receivedRequestsMethods = getRequestsMethods(targetRequests)
   const expectedMethod = options?.method
 
   if (methodDoesNotMatch(expectedMethod, receivedRequestsMethods)) {
-    return {
-      pass: false,
-      message: () =>
-        `Fetch method does not match, expected ${ expectedMethod } received ${ receivedRequestsMethods }`,
-    }
+    return methodDoesNotMatchErrorMessage(expectedMethod, receivedRequestsMethods)
   }
 
   const receivedRequestsBodies = getRequestsBodies(targetRequests)
   const expectedBody = options?.body
 
   if (bodyDoesNotMatch(expectedBody, receivedRequestsBodies)) {
-    return {
-      pass: false,
-      message: () =>
-        `Fetch body does not match, expected ${ JSON.stringify(
-          expectedBody,
-        ) } received ${ JSON.stringify(receivedRequestsBodies) }`,
-    }
+    return bodyDoesNotMatchErrorMessage(expectedBody, receivedRequestsBodies)
   }
 
-  return { message: () => undefined, pass: true }
+  return successMessage()
 }
 
 export { toHaveBeenFetchedWith }

--- a/tests/assertions/toHaveBeenFetchedWith.test.js
+++ b/tests/assertions/toHaveBeenFetchedWith.test.js
@@ -1,4 +1,5 @@
 import { assertions } from '../../src'
+import { green, red } from 'chalk'
 
 expect.extend(assertions)
 
@@ -21,7 +22,7 @@ describe('toHaveBeenFetchedWith', () => {
     await fetch(new Request(path))
     const { message } = await assertions.toHaveBeenFetchedWith(expectedPath)
 
-    expect(message()).toBe("/some/unknown ain't got called")
+    expect(message()).toBe("🌯 Burrito: /some/unknown ain't got called")
     expect(expectedPath).not.toHaveBeenFetchedWith()
   })
 
@@ -137,9 +138,12 @@ describe('toHaveBeenFetchedWith', () => {
       })
 
       expect(message()).toBe(
-        `Fetch body does not match, expected ${ JSON.stringify(
-          expectedBody,
-        ) } received ${ JSON.stringify([receivedBody]) }`,
+        `🌯 Burrito: Fetch body does not match.
+Expected:
+${green(JSON.stringify(expectedBody, null, ' '))}
+
+Received:
+${red(JSON.stringify([receivedBody], null, ' '))}`,
       )
       expect(path).not.toHaveBeenFetchedWith({
         body: expectedBody,
@@ -226,7 +230,7 @@ describe('toHaveBeenFetchedWith', () => {
       })
 
       expect(message()).toBe(
-        'Fetch method does not match, expected POST received PUT',
+        '🌯 Burrito: Fetch method does not match, expected POST received PUT',
       )
       expect(path).not.toHaveBeenFetchedWith({
         method: 'POST',


### PR DESCRIPTION
## :camera_flash: Screenshots/Gif/Videos
<!--- Drag and drop your screenshot here -->

Before | After
---|---
![before image](https://user-images.githubusercontent.com/16082422/113520261-154c0700-9592-11eb-8ca2-ec7e7b82098d.png) | ![after image](https://user-images.githubusercontent.com/16082422/113520263-1715ca80-9592-11eb-867e-331610b4a2d7.png)


## :tophat: What?
<!--- Describe your changes in detail -->
- Improved the `toHaveBeenFetchedWith` assertion error messages
- Added the `🌯 Burrito: ` message to know when the message comes from the library
## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- It was difficult to distinguish the content of the body 🔍
- To highlight the burrito messages ✨
## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->
Updating the tests that were checking the messages with the new beautiful format ✌️

## :speaking_head: Comments
The **JSON.stringify()** method converts a JavaScript object or value to a JSON string, optionally replacing values if a replacer function is specified or optionally including only the specified properties if a replacer array is specified.

The space argument may be used to control spacing in the final string. 👇
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_space_argument