### PR TITLE
[Added] Assertion toHaveBeenFetched

### DIFF
--- a/src/assertions/fetch.js
+++ b/src/assertions/fetch.js
@@ -80,4 +80,9 @@ const toHaveBeenFetchedWith = (path, options) => {
   return successMessage()
 }
 
-export { toHaveBeenFetchedWith }
+const toHaveBeenFetched = (path) => {
+  const requests = findRequestsByPath(path)
+  return !requests.length ? emptyErrorMessage(path) : successMessage()
+}
+
+export { toHaveBeenFetchedWith, toHaveBeenFetched }

--- a/src/assertions/index.js
+++ b/src/assertions/index.js
@@ -1,9 +1,10 @@
 import { toMatchNetworkRequests } from './toMatchNetworkRequests'
-import { toHaveBeenFetchedWith } from './toHaveBeenFetchedWith'
+import { toHaveBeenFetchedWith, toHaveBeenFetched } from './fetch'
 
 const assertions = {
   toMatchNetworkRequests,
   toHaveBeenFetchedWith,
+  toHaveBeenFetched,
 }
 
 export { assertions }

--- a/tests/assertions/toHaveBeenFetched.test.js
+++ b/tests/assertions/toHaveBeenFetched.test.js
@@ -1,0 +1,27 @@
+import { assertions } from '../../src'
+
+expect.extend(assertions)
+
+describe('toHaveBeenFetched', () => {
+  it('should check that the path has been called', async () => {
+    const path = '//some-domain.com/some/path/'
+    const expectedPath = '/some/path/'
+
+    await fetch(new Request(path))
+    const { message } = await assertions.toHaveBeenFetched(expectedPath)
+
+    expect(message()).toBeUndefined()
+    expect(expectedPath).toHaveBeenFetched()
+  })
+
+  it('should check that the path has not been called', async () => {
+    const path = '//some-domain.com/some/path/'
+    const expectedPath = '/some/unknown'
+
+    await fetch(new Request(path))
+    const { message } = await assertions.toHaveBeenFetched(expectedPath)
+
+    expect(message()).toBe("🌯 Burrito: /some/unknown ain't got called")
+    expect(expectedPath).not.toHaveBeenFetched()
+  })
+})


### PR DESCRIPTION
## :tophat: What?
Add assertion `toHaveBeenFetched` that returns a boolean wether a path has been fetched or not.
## :thinking: Why?
This functionality already existed by calling `toHaveBeenFetchedWith` with no arguments, but we think it can lead to confusion on what it actually means.

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
Added tests very similar to `toHaveBeenFetchedWith`
