### PR TITLE
[Removed] withPortalAt builder method

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ and add the previous file in `jest.config.json`
   ],
 ```
 
+If one or more of your components use a `react portal` in any way, you will need to specify the `id` of the node where it will be added:
+
+```
+import { render } from '@testing-library/react'
+import { configure } from '@mercadona/mo.library.burrito'
+
+configure({
+  mount: render,
+  portal: 'modal-root',
+})
+```
+
 ## 🏰 Builder API
 
 #### withMocks (Deprecated)
@@ -170,16 +182,6 @@ wrap(MyComponent)
   .mount()
 ```
 
-#### withPortalAt
-If one or more of your components use a `react portal` in any way, you will need to specify the `id` of the node where it will be added:
-```
-import { wrap } from '@mercadona/mo.library.burrito'
-
-wrap(PreparationContainer)
-  .withPortalAt('modal-root')
-  .mount()
-```
-
 #### composing
 As it is basically a builder, all the above functions can be used at the same time and these will be composed underneath:
 ```
@@ -195,7 +197,6 @@ wrap(PreparationContainer)
   .atPath('/products/1')
   .withNetwork(responses)
   .withProps()
-  .withPortalAt('modal-root')
   .mount()
 ```
 

--- a/src/wrap.js
+++ b/src/wrap.js
@@ -55,8 +55,6 @@ const wrap = options => {
 
   return {
     withProps: props => wrap({ ...options, props }),
-    withPortalAt: portalRootId =>
-      wrap({ ...options, portalRootId, hasPortal: true }),
     withMocks: responses => {
       console.warn(yellow('withMocks is deprecated. Use withNetwork instead.'))
       return wrap({ ...options, responses, hasMocks: true })
@@ -71,23 +69,12 @@ const wrap = options => {
     ...extensions,
     atPath: path => wrap({ ...options, path, hasPath: true }),
     mount: () => {
-      const {
-        hasMocks,
-        responses,
-        hasPortal,
-        portalRootId,
-        path,
-        hasPath,
-      } = options
+      const { hasMocks, responses, path, hasPath } = options
 
       if (hasMocks) {
         mockFetch(responses)
       } else {
         mockNetwork(responses)
-      }
-
-      if (hasPortal) {
-        setupPortal(portalRootId)
       }
 
       if (portal) {

--- a/tests/wrap.test.js
+++ b/tests/wrap.test.js
@@ -1,13 +1,19 @@
-import { render, cleanup } from '@testing-library/react'
+import { render, cleanup } from '@testing-library/react'
 import { wrap, configure } from '../src/index'
 import { getConfig } from '../src/config'
-import { MyComponent, MyComponentWithProps, MyComponentWithPortal } from './components.mock'
+import {
+  MyComponent,
+  MyComponentWithProps,
+  MyComponentWithPortal,
+} from './components.mock'
 
 const portalRootId = 'portal-root-id'
 
 const removePortals = portalRootId => {
   const portal = document.getElementById(portalRootId)
-  if (!portal) { return }
+  if (!portal) {
+    return
+  }
   document.body.removeChild(portal)
 }
 
@@ -40,22 +46,13 @@ it('should have an element where to place a portal defined in the config', () =>
   expect(document.body).toHaveTextContent(childrenText)
 })
 
-it('should have an element where to place a portal', () => {
-  const childrenText = 'I am a portal'
-  const props = { children: childrenText }
-
-  wrap(MyComponentWithPortal).withProps(props).withPortalAt(portalRootId).mount()
-
-  expect(document.body).toHaveTextContent(childrenText)
-})
-
 it('should have unique portals', () => {
-  configure({ mount: render })
+  configure({ mount: render, portal: portalRootId })
   const childrenText = 'I am a portal'
   const props = { children: childrenText }
 
-  wrap(MyComponentWithPortal).withProps(props).withPortalAt(portalRootId).mount()
-  wrap(MyComponentWithPortal).withProps(props).withPortalAt(portalRootId).mount()
+  wrap(MyComponentWithPortal).withProps(props).mount()
+  wrap(MyComponentWithPortal).withProps(props).mount()
 
   expect(document.querySelectorAll(`#${ portalRootId }`)).toHaveLength(1)
 })


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
- Remove `withPortalAt` builder method
- Update README so that it includes information about the `portal` config option

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We already have the `portal` config option that does the same and can be set globally. More info in [this issue](https://github.com/mercadona/mo.library.burrito/issues/65).

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->
Updated a test checking that even when mounting two apps using the same portal reference, there is only one portal in the DOM

## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
