### PR TITLE
[Changed] Split the wrap builder from the public interface

### DIFF
--- a/src/wrap.js
+++ b/src/wrap.js
@@ -29,40 +29,40 @@ const extendWith = (extensions, options) => {
           },
           args,
         )
-        return wrap(options)
+        return getWrap(options)
       },
     }),
     {},
   )
 }
 
-const wrap = options => {
-  const isComponent = typeof options === 'function'
-  const isWrappedComponent = typeof options.WrappedComponent === 'function'
+const wrap = Component => {
+  return getWrap({
+    Component,
+    responses: [],
+    props: {},
+    path: '',
+    hasPath: false,
+    debug: false,
+  })
+}
 
-  if (isComponent || isWrappedComponent) {
-    return wrap({ Component: options })
-  }
-
-  if (!options.responses) {
-    return wrap({ ...options, responses: [] })
-  }
-
+const getWrap = options => {
   const { extend, portal, history } = getConfig()
   const extensions = extendWith(extend, options)
 
   return {
-    withProps: props => wrap({ ...options, props }),
+    withProps: props => getWrap({ ...options, props }),
     withNetwork: (responses = []) => {
       const listOfResponses = Array.isArray(responses) ? responses : [responses]
-      return wrap({
+      return getWrap({
         ...options,
         responses: [...options.responses, ...listOfResponses],
       })
     },
     ...extensions,
-    atPath: path => wrap({ ...options, path, hasPath: true }),
-    debugRequests: () => wrap({ ...options, debug: true }),
+    atPath: path => getWrap({ ...options, path, hasPath: true }),
+    debugRequests: () => getWrap({ ...options, debug: true }),
     mount: () => {
       const { responses, path, hasPath, debug } = options
 
@@ -84,7 +84,7 @@ const wrap = options => {
   }
 }
 
-function setupPortal(portalRootId) {
+const setupPortal = portalRootId => {
   if (document.getElementById(portalRootId)) {
     return
   }
@@ -95,6 +95,6 @@ function setupPortal(portalRootId) {
 }
 
 const mount = ({ Component, props }) =>
-  getConfig().mount(<Component { ...props } />)
+  getConfig().mount(<Component {...props} />)
 
 export { wrap }


### PR DESCRIPTION
## :camera_flash: Screenshots/Gif/Videos
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->

## :tophat: What?
<!--- Describe your changes in detail -->
We split the wrap builder from the public interface. We are using the same function for different responsibilities.

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The builder pattern includes code for the public interface and it isn't readable because we need to check some properties to choose the proper path.

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->
We have some tests covering this code and continue passing.

## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
