### PR TITLE
[Changed] Split the wrap closure in functions

### DIFF
--- a/src/wrap.js
+++ b/src/wrap.js
@@ -21,10 +21,10 @@ const wrap = Component => {
     debug: false,
   }
 
-  return getWrap(options)
+  return wrapWith(options)
 }
 
-const getWrap = options => {
+const wrapWith = options => {
   const { extend, portal, history, mount } = getConfig()
   const extensions = extendWith(extend, options)
 
@@ -56,7 +56,7 @@ const extendWith = (extensions, options) => {
           },
           args,
         )
-        return getWrap(options)
+        return wrapWith(options)
       },
     }),
     {},
@@ -64,7 +64,7 @@ const extendWith = (extensions, options) => {
 }
 
 const getWithProps = options => props => {
-  return getWrap({ ...options, props })
+  return wrapWith({ ...options, props })
 }
 
 const getWithNetwork =
@@ -72,18 +72,18 @@ const getWithNetwork =
   (responses = []) => {
     const listOfResponses = Array.isArray(responses) ? responses : [responses]
 
-    return getWrap({
+    return wrapWith({
       ...options,
       responses: [...options.responses, ...listOfResponses],
     })
   }
 
 const getAtPath = options => path => {
-  return getWrap({ ...options, path, hasPath: true })
+  return wrapWith({ ...options, path, hasPath: true })
 }
 
 const getDebugRequest = options => () => {
-  return getWrap({ ...options, debug: true })
+  return wrapWith({ ...options, debug: true })
 }
 
 const getMount = (options, portal, history, mount) => () => {


### PR DESCRIPTION
## :camera_flash: Screenshots/Gif/Videos
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->

## :tophat: What?
<!--- Describe your changes in detail -->
We split the wrap closure into different functions using currying transformation to pass options property.

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Divide and conquers, we want to refactor this file and split the code into functions in order to do it more readable and maintainable.

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->
All tests are still passing

## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
