### PR TITLE
[Fixed] Do not copy npmrc file when doing build

### DIFF
--- a/scripts/copy-publish-files.js
+++ b/scripts/copy-publish-files.js
@@ -2,8 +2,5 @@ const fs = require('fs')
 const packageJson = fs.readFileSync('package.json').toString()
 fs.writeFileSync('dist/package.json', packageJson)
 
-const npmConfig = fs.readFileSync('.npmrc').toString()
-fs.writeFileSync('dist/.npmrc', npmConfig)
-
 const readme = fs.readFileSync('README.md').toString()
 fs.writeFileSync('dist/README.md', readme)


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Do not copy npmrc file when doing build

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We don't use that file anymore

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->

## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
