### PR TITLE
[Added] changeRoute function to config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ let config: Config = {
   defaultHost: '',
   extend: {},
   mount,
-  changeRoute: (path: string) => window.history.replaceState(null, '', path)
+  changeRoute: (path: string) => window.history.replaceState(null, '', path),
 }
 
 function configure(newConfig: Config) {

--- a/src/models.ts
+++ b/src/models.ts
@@ -48,7 +48,12 @@ interface Config {
   mount: Mount
   extend: Extensions
   changeRoute: (path: string) => void
+  history?: BrowserHistory 
   portal?: string
 }
 
-export { Wrap, WrapOptions, Response, Config, Mount, Component }
+interface BrowserHistory extends History {
+  push: (path: string) => void
+}
+
+export { Wrap, WrapOptions, Response, Config, Mount, Component, BrowserHistory }

--- a/src/wrap.tsx
+++ b/src/wrap.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { mockNetwork } from './mockNetwork'
 import { getConfig, Mount } from './config'
-import { Response, Wrap, WrapOptions } from './models'
+import { BrowserHistory, Response, Wrap, WrapOptions } from './models'
 
 beforeEach(() => {
   global.fetch = jest.fn()
@@ -27,7 +27,7 @@ const wrap = (Component: typeof React.Component): Wrap => {
 }
 
 const wrapWith = (options: WrapOptions): Wrap => {
-  const { extend, portal, changeRoute, mount } = getConfig()
+  const { extend, portal, changeRoute, history, mount } = getConfig()
   const extensions = extendWith(extend, options)
 
   return {
@@ -35,7 +35,7 @@ const wrapWith = (options: WrapOptions): Wrap => {
     withNetwork: getWithNetwork(options),
     atPath: getAtPath(options),
     debugRequests: getDebugRequest(options),
-    mount: getMount(options, mount, changeRoute, portal),
+    mount: getMount(options, mount, changeRoute, history, portal),
     ...extensions,
   }
 }
@@ -95,6 +95,7 @@ const getMount =
     options: WrapOptions,
     mount: Mount,
     changeRoute: (path: string) => void,
+    history?: BrowserHistory,
     portal?: string,
   ) =>
   () => {
@@ -104,7 +105,11 @@ const getMount =
       setupPortal(portal)
     }
 
-    if (hasPath) {
+    if (hasPath && history) {
+      history.push(path)
+    }
+
+    if (hasPath && !history) {
       changeRoute(path)
     }
 

--- a/tests/atPath.test.js
+++ b/tests/atPath.test.js
@@ -23,9 +23,18 @@ it('should render an app without routing with specific url', () => {
   expect(window.location.href).toBe('http://localhost/?query=query')
 })
 
-it('should render an app with routing given an specific path', () => {
+it('should render an app with routing given an specific path using changeRoute', () => {
   const functionCalledByHomeRoute = jest.spyOn(myFakeModule, 'myFakeFunction')
   configure({ changeRoute: history.push })
+  const { container } = wrap(MyAppWithRouting).atPath('/categories').mount()
+
+  expect(functionCalledByHomeRoute).not.toHaveBeenCalledWith('HOME')
+  expect(container).toHaveTextContent('Categories')
+})
+
+it('should render an app with routing given an specific path using history', () => {
+  const functionCalledByHomeRoute = jest.spyOn(myFakeModule, 'myFakeFunction')
+  configure({ history })
   const { container } = wrap(MyAppWithRouting).atPath('/categories').mount()
 
   expect(functionCalledByHomeRoute).not.toHaveBeenCalledWith('HOME')
@@ -42,4 +51,3 @@ it('should render an app with a routing logic between pages', () => {
 
   expect(container).toHaveTextContent('Categories')
 })
-


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Add `changeRoute` fn that will end replacing the `history` object in config. https://github.com/mercadona/wrapito/issues/70

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`history` is an object with many features, but it is 100% coupled to `react-router` library. In order to make `wrapito` more agnostic and more configurable by project, `changeRoute` has been added, which is a config property that receives a function to be called passing the `path` param. This way, it will work no matter what library is being used. It actually kind of works with native js routing by default.
`history` will be deprecated in coming PRs.

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->
Updated tests checking the `atPath` feature so that these have the `changeRoute` in the config instead of the `history`

## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
