### PR TITLE
[Deprecated] history object from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,17 @@ wrap(MyComponent)
   .mount()
 ```
 
+By default it will use the native javascript history API, but you can provide a method to be called for change the app route with [`changeRoute`](#changeRoute):
+```js
+import { configure } from 'wrapito'
+import { history } from 'app.js'
+
+configure({
+  ..configuration,
+  changeRoute: (route) => history.push(route)
+})
+```
+
 #### withProps
 Pass down the props to the wrapped component:
 ```js

--- a/src/wrap.tsx
+++ b/src/wrap.tsx
@@ -106,6 +106,7 @@ const getMount =
     }
 
     if (hasPath && history) {
+      console.warn('wrapito WARNING: history is DEPRECATED. Pass a changeRoute function to the config instead.')
       history.push(path)
     }
 

--- a/src/wrap.tsx
+++ b/src/wrap.tsx
@@ -107,6 +107,7 @@ const getMount =
 
     if (hasPath && history) {
       console.warn('wrapito WARNING: history is DEPRECATED. Pass a changeRoute function to the config instead.')
+      console.warn('Read about changeRounte in: https://github.com/mercadona/wrapito#changeRoute')
       history.push(path)
     }
 

--- a/tests/atPath.test.js
+++ b/tests/atPath.test.js
@@ -41,6 +41,17 @@ it('should render an app with routing given an specific path using history', () 
   expect(container).toHaveTextContent('Categories')
 })
 
+it('should warn that history config is deprecated', () => {
+  const warn = jest.spyOn(console, 'warn')
+  configure({ history })
+  wrap(MyAppWithRouting).atPath('/categories').mount()
+
+  expect(warn).toHaveBeenCalledWith(
+    'wrapito WARNING: history is DEPRECATED. Pass a changeRoute function to the config instead.',
+  )
+  configure({ history: null })
+})
+
 it('should render an app with a routing logic between pages', () => {
   configure({ changeRoute: history.push })
   const { container, getByText } = wrap(MyAppWithRouting).atPath('/').mount()


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Deprecate history object from config

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We have added `changeRoute` to the config for this purpose, which is more agnostic

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->
Adding a test to check that the warning message is logged when history is used

## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
Related issue https://github.com/mercadona/wrapito/issues/109