### PR TITLE
[Added] Success message for `toHaveBeenFetch` method

### DIFF
--- a/src/assertions/fetch.js
+++ b/src/assertions/fetch.js
@@ -6,6 +6,7 @@ import {
   bodyDoesNotMatchErrorMessage,
   doesNotHaveBodyErrorMessage,
   successMessage,
+  haveBeenFetchedSuccessMessage,
 } from './messages'
 
 const findRequestsByPath = path =>
@@ -64,7 +65,7 @@ const toHaveBeenFetchedWith = (path, options) => {
 
 const toHaveBeenFetched = path => {
   const requests = findRequestsByPath(path)
-  return !requests.length ? emptyErrorMessage(path) : successMessage()
+  return !requests.length ? emptyErrorMessage(path) : haveBeenFetchedSuccessMessage(path)
 }
 
 const toHaveBeenFetchedTimes = (path, expectedLength) => {

--- a/src/assertions/messages.js
+++ b/src/assertions/messages.js
@@ -38,6 +38,11 @@ const successMessage = () => ({
   message: () => undefined,
 })
 
+const haveBeenFetchedSuccessMessage = (path) => ({
+  pass: true,
+  message: () => `🌯 Wrapito: ${path} is called`,
+})
+
 export {
   emptyErrorMessage,
   fetchLengthErrorMessage,
@@ -45,4 +50,5 @@ export {
   bodyDoesNotMatchErrorMessage,
   doesNotHaveBodyErrorMessage,
   successMessage,
+  haveBeenFetchedSuccessMessage,
 }

--- a/tests/assertions/toHaveBeenFetched.test.js
+++ b/tests/assertions/toHaveBeenFetched.test.js
@@ -10,7 +10,7 @@ describe('toHaveBeenFetched', () => {
     await fetch(new Request(path))
     const { message } = await assertions.toHaveBeenFetched(expectedPath)
 
-    expect(message()).toBeUndefined()
+    expect(message()).toBe('🌯 Wrapito: /some/path/ is called')
     expect(expectedPath).toHaveBeenFetched()
   })
 


### PR DESCRIPTION
## :camera_flash: Screenshots/Gif/Videos

Before | After
---|---
![before image](https://user-images.githubusercontent.com/16082422/132224693-d9b43774-a3f1-448d-a451-46c62739f3d5.png) | ![after image](https://user-images.githubusercontent.com/16082422/132224782-7dc413d2-2839-421a-91d3-bb4cd506e54c.png)


## :tophat: What?
<!--- Describe your changes in detail -->
Added a message for `toHaveBeenFetch()` method
## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- https://github.com/mercadona/wrapito/issues/89
## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->
Updating the test that was checking the "undefined" message