### PR TITLE
[Changed] Get default debug value from params

### DIFF
--- a/src/wrap.tsx
+++ b/src/wrap.tsx
@@ -20,7 +20,7 @@ const wrap = (Component: typeof React.Component): Wrap => {
     props: {},
     path: '',
     hasPath: false,
-    debug: false,
+    debug: process.env.npm_config_debugRequests === 'true',
   }
 
   return wrapWith(options)

--- a/tests/withNetwork.test.js
+++ b/tests/withNetwork.test.js
@@ -29,22 +29,6 @@ it('should have network with an array of requests', async () => {
   expect(console.warn).not.toHaveBeenCalled()
 })
 
-it('should have network with an object of requests', async () => {
-  jest.spyOn(console, 'warn')
-  configure({ mount: render })
-  wrap(MyComponentWithNetwork)
-    .withNetwork({
-      path: '/path/with/response/',
-      host: 'my-host',
-      responseBody: '15',
-    })
-    .mount()
-
-  expect(await screen.findByText('SUCCESS')).toBeInTheDocument()
-  expect(await screen.findByText('15')).toBeInTheDocument()
-  expect(console.warn).not.toHaveBeenCalled()
-})
-
 it('should have network without responses', async () => {
   configure({ mount: render })
   wrap(MyComponentWithNetwork).withNetwork().mount()


### PR DESCRIPTION
## :tophat: What?
Allow to pass `--debugRequests` to `npm run test` command in order to debug the requests

## :thinking: Why?
To prevent forgetting the `.debugRequests()` line in all PRs :) 

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
Checked that debugRequests works when param is passed
