### PR TITLE
[Changed] Add types to mockNetwork

### DIFF
--- a/src/mockNetwork.ts
+++ b/src/mockNetwork.ts
@@ -1,12 +1,20 @@
+// @ts-nocheck
 import { white, redBright, greenBright } from 'chalk'
+import { Response } from './models'
 import { getRequestMatcher } from './requestMatcher'
 
+declare global {
+  interface Window {
+    fetch: jest.Mock
+  }
+}
+
 beforeEach(() => {
-  global.fetch = jest.fn()
+  global.window.fetch = jest.fn()
 })
 
 afterEach(() => {
-  global.fetch.mockRestore()
+  global.window.fetch.mockRestore()
 })
 
 const createResponse = async ({
@@ -33,18 +41,18 @@ const createResponse = async ({
 
 const printRequest = request => {
   return console.warn(`
-${ white.bold.bgRed('wrapito') } ${ redBright.bold(
-  'cannot find any mock matching:',
-) }
-  ${ greenBright(`URL: ${ request.url }`) }
-  ${ greenBright(`METHOD: ${ request.method.toLowerCase() }`) }
-  ${ greenBright(`REQUEST BODY: ${ request._bodyInit }`) }
+${white.bold.bgRed('wrapito')} ${redBright.bold(
+    'cannot find any mock matching:',
+  )}
+  ${greenBright(`URL: ${request.url}`)}
+  ${greenBright(`METHOD: ${request.method.toLowerCase()}`)}
+  ${greenBright(`REQUEST BODY: ${request._bodyInit}`)}
  `)
 }
 
-function mockNetwork(responses = [], debug = false) {
+function mockNetwork(responses: Response[] = [], debug: boolean = false) {
   const listOfResponses = responses.length > 0 ? responses : [responses]
-  global.fetch.mockImplementation(async request => {
+  global.window.fetch.mockImplementation(async request => {
     const responseMatchingRequest = listOfResponses.find(
       getRequestMatcher(request),
     )

--- a/src/mockNetwork.ts
+++ b/src/mockNetwork.ts
@@ -27,12 +27,13 @@ const createDefaultResponse = async () => {
   return Promise.resolve(response)
 }
 
-const createResponse = async ({
-  responseBody,
-  status = 200,
-  headers,
-  delay,
-}: Response) => {
+const createResponse = async (mockResponse: Response) => {
+  const {
+    responseBody,
+    status = 200,
+    headers,
+    delay,
+  } = mockResponse
   const response = {
     json: () => Promise.resolve(responseBody),
     status,

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,19 +1,23 @@
 import React from 'react'
 
-interface Response {
+interface WrapRequest extends Request {
+  _bodyInit: string,
+}
+
+interface WrapResponse extends Response {
   path: string
   method?: string
-  status?: number
   host?: string
   responseBody?: object
   requestBody?: object
-  multipleResponses?: Response[]
+  multipleResponses?: WrapResponse[]
   catchParams?: boolean
   delay?: number
+  hasBeenReturned?: boolean
 }
 
 interface Wrap {
-  withNetwork: (responses: Response[]) => Wrap
+  withNetwork: (responses: WrapResponse[]) => Wrap
   atPath: (path: string) => Wrap
   withProps: (props: object) => Wrap
   debugRequests: () => Wrap
@@ -22,7 +26,7 @@ interface Wrap {
 
 interface WrapOptions {
   Component: typeof React.Component
-  responses: Response[]
+  responses: WrapResponse[]
   props: object
   path: string
   hasPath: boolean
@@ -30,7 +34,7 @@ interface WrapOptions {
 }
 
 interface WrapExtensionAPI {
-  addResponses: (responses: Response[]) => void
+  addResponses: (responses: WrapResponse[]) => void
 }
 
 type Extension = <T>(extensionAPI: WrapExtensionAPI, args: T) => Wrap
@@ -57,7 +61,8 @@ interface BrowserHistory extends History {
 }
 
 export {
-  Response,
+  WrapRequest as Request,
+  WrapResponse as Response,
   Config,
   Mount,
   Component,


### PR DESCRIPTION
## :camera_flash: Screenshots/Gif/Videos
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->

## :tophat: What?
<!--- Describe your changes in detail -->
We added some types to `mockNetwork` but we also did some changes to simplify the types:
- We create the function `createDefaultResponse` extracting it from the `createResponse` function.
- We change the import of `chalk` library to solve the type issue.
- We extract `mockFetch` from `mockNetwork` thinking on improve the code in another step.

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to migrate the library to TS and this PR is part of the migration.

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->
All tests keep passing.

## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
