### PR TITLE
Refactoring how to use status options

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -9,4 +9,6 @@ const updateOptions = (updatedOptions: WrapOptions) => {
   }
 }
 
-export { options, updateOptions }
+const getOptions = () : WrapOptions => ({ ...options })
+
+export { options, updateOptions, getOptions }

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,0 +1,12 @@
+import { WrapOptions } from "./models";
+
+let options: WrapOptions
+
+const updateOptions = (updatedOptions: WrapOptions) => {
+  options = {
+    ...options,
+    ...updatedOptions,
+  }
+}
+
+export { options, updateOptions }

--- a/src/wrap.tsx
+++ b/src/wrap.tsx
@@ -46,38 +46,38 @@ const wrapWith = (): Wrap => {
   }
 }
 
-const addResponses = () => (newResponses: Response[]) => {
+const addResponses = (newResponses: Response[]) => {
   const options = getOptions()
   const responses = [...options.responses, ...newResponses]
+
   updateOptions({ ...options, responses })
 }
 
 const applyExtension = (args: any[], extension: Extension) => {
-  const wrapExtensionAPI: WrapExtensionAPI = {
-    addResponses: addResponses(),
-  }
+  const wrapExtensionAPI: WrapExtensionAPI = { addResponses }
 
   extension(wrapExtensionAPI, args)
 
   return wrapWith()
 }
 
-const buildExtensions =
-  (extensions: Extensions) =>
-  (alreadyExtended: Extensions, extensionName: string): Extensions => {
-    const extension = extensions[extensionName]
-    return {
-      ...alreadyExtended,
-      [extensionName]: (...args: any) => applyExtension(args, extension),
-    }
+const buildExtensions = (
+  alreadyExtended: Extensions,
+  extensionName: string,
+): Extensions => {
+  const { extend: extensions } = getConfig()
+  const extension = extensions[extensionName]
+  return {
+    ...alreadyExtended,
+    [extensionName]: (...args: any) => applyExtension(args, extension),
   }
+}
 
 const extendWith = () => {
   const { extend: extensions } = getConfig()
-  if (!extensions) return {}
-
   const extensionNames = Object.keys(extensions)
-  return extensionNames.reduce(buildExtensions(extensions), {})
+
+  return extensionNames.reduce(buildExtensions, {})
 }
 
 const withProps = (props: object) => {

--- a/src/wrap.tsx
+++ b/src/wrap.tsx
@@ -49,8 +49,9 @@ const wrapWith = (): Wrap => {
   }
 }
 
-const addResponses = () => (responses: Response[]) => {
-  options.responses = [...options.responses, ...responses]
+const addResponses = () => (newResponses: Response[]) => {
+  const responses = [...options.responses, ...newResponses]
+  updateOptions({ ...options, responses })
 }
 
 const applyExtension = (

--- a/src/wrap.tsx
+++ b/src/wrap.tsx
@@ -2,11 +2,11 @@ import React from 'react'
 
 import { mockNetwork } from './mockNetwork'
 import { getConfig, Mount } from './config'
+import { options, updateOptions } from './options'
 import {
   BrowserHistory,
   Response,
   Wrap,
-  WrapOptions,
   WrapExtensionAPI,
   Extension,
   Extensions,
@@ -21,17 +21,16 @@ afterEach(() => {
   mockedFetch.mockRestore()
 })
 
-let options: WrapOptions
 
 const wrap = (Component: typeof React.Component): Wrap => {
-  options = {
+  updateOptions({
     Component: Component,
     responses: [],
     props: {},
     path: '',
     hasPath: false,
     debug: process.env.npm_config_debugRequests === 'true',
-  }
+  })
 
   return wrapWith()
 }
@@ -84,7 +83,7 @@ const extendWith = (extensions: Extensions) => {
 }
 
 const getWithProps = () => (props: object) => {
-  options = { ...options, props }
+  updateOptions({ ...options, props })
   return wrapWith()
 }
 
@@ -93,21 +92,21 @@ const getWithNetwork =
   (responses: Response[] = []) => {
     const listOfResponses = Array.isArray(responses) ? responses : [responses]
 
-    options = {
+    updateOptions({
       ...options,
       responses: [...options.responses, ...listOfResponses],
-    }
+    })
 
     return wrapWith()
   }
 
 const getAtPath = () => (path: string) => {
-  options = { ...options, path, hasPath: true }
+  updateOptions({ ...options, path, hasPath: true })
   return wrapWith()
 }
 
 const getDebugRequest = () => () => {
-  options = { ...options, debug: true }
+  updateOptions({ ...options, debug: true })
 
   return wrapWith()
 }


### PR DESCRIPTION
## :camera_flash: Screenshots/Gif/Videos
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->

## :tophat: What?
<!--- Describe your changes in detail -->
We refactored some parts of the code to reduce currying, making the code simple and readable by encapsulating the complexity of the options state in a module as a "singleton".

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order to migrate to TS, we decide to split the code into small parts and we use a lot of the curry resource doing the come more complex. It's could be another approach.

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->
All tests keep passing.

## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
In the future, we could try to create different modules with more coupling and cohesion. Will see!