### PR TITLE
[Fixed] toHaveBeenFetchedTimes assertion to match path and search

### DIFF
--- a/src/assertions/fetch.js
+++ b/src/assertions/fetch.js
@@ -9,8 +9,19 @@ import {
   haveBeenFetchedSuccessMessage,
 } from './messages'
 
-const findRequestsByPath = path =>
-  fetch.mock.calls.filter(call => call[0].url.includes(path))
+const findRequestsByPath = expectedPath =>
+  fetch.mock.calls.filter(call => {
+    const callURL = new URL(call[0].url, "https://default.com")
+    const expectedURL = new URL(expectedPath, "https://default.com")
+    const matchPathName = callURL.pathname === expectedURL.pathname
+    const matchSearchParams = callURL.search === expectedURL.search
+
+    if (expectedURL.search) {
+      return matchPathName && matchSearchParams
+    }
+
+    return matchPathName
+  })
 
 const getRequestsMethods = requests =>
   requests.map(request => request[0]?.method)

--- a/tests/assertions/toHaveBeenFetchedTimes.test.js
+++ b/tests/assertions/toHaveBeenFetchedTimes.test.js
@@ -13,6 +13,35 @@ describe('toHaveBeenFetchedTimes', () => {
     expect(expectedPath).toHaveBeenFetchedTimes(2)
   })
 
+  it('should match the whole url', async () => {
+    const path = '//some-domain.com/some/path/'
+    const similarPath = '//some-domain.com/some/path/with/something/else/'
+    const expectedPath = '/some/path/'
+
+    await fetch(new Request(path))
+    await fetch(new Request(similarPath))
+
+    expect(expectedPath).toHaveBeenFetchedTimes(1)
+  })
+
+  it('should match the url without query params', async () => {
+    const path = '//some-domain.com/some/path/?foo=bar'
+    const expectedPath = '/some/path/'
+
+    await fetch(new Request(path))
+
+    expect(expectedPath).toHaveBeenFetchedTimes(1)
+  })
+
+  it('should match the url with query params', async () => {
+    const path = '//some-domain.com/some/path/?foo=bar'
+    const expectedPath = '/some/path/?foo=bar'
+
+    await fetch(new Request(path))
+
+    expect(expectedPath).toHaveBeenFetchedTimes(1)
+  })
+
   it('should check that the path has not been called', async () => {
     const path = '//some-domain.com/some/path/'
     const expectedPath = '/some/path/'


### PR DESCRIPTION
## :camera_flash: Screenshots/Gif/Videos
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->

## :tophat: What?
toHaveBeenFetchedTimes assertion to match path and search
<!--- Describe your changes in detail -->

## :thinking: Why?
It was not working well when you try to match a path like `/my/path/` and you are also calling to the path `/my/path/something/else/`
The expect `expect('/my/path/')toHaveBeenFetchedTimes(n)` returns 2 instead of 1.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
Adding test to check the uncover scenarios
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->

## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
