### PR TITLE
[Fixed] toHaveBeenFetchedTimes assert with default host

### DIFF
--- a/src/assertions/fetch.js
+++ b/src/assertions/fetch.js
@@ -1,4 +1,5 @@
 import deepEqual from 'deep-equal'
+import { getConfig } from '../config'
 import {
   emptyErrorMessage,
   fetchLengthErrorMessage,
@@ -11,8 +12,10 @@ import {
 
 const findRequestsByPath = expectedPath =>
   fetch.mock.calls.filter(call => {
+    const { defaultHost } = getConfig()
     const callURL = new URL(call[0].url, "https://default.com")
-    const expectedURL = new URL(expectedPath, "https://default.com")
+    const finalExpectedPath = expectedPath.includes(defaultHost) ? expectedPath : defaultHost + expectedPath
+    const expectedURL = new URL(finalExpectedPath, "https://default.com")
     const matchPathName = callURL.pathname === expectedURL.pathname
     const matchSearchParams = callURL.search === expectedURL.search
 

--- a/tests/assertions/toHaveBeenFetchedTimes.test.js
+++ b/tests/assertions/toHaveBeenFetchedTimes.test.js
@@ -1,4 +1,4 @@
-import { assertions } from '../../src'
+import { assertions, configure } from '../../src'
 
 expect.extend(assertions)
 
@@ -40,6 +40,31 @@ describe('toHaveBeenFetchedTimes', () => {
     await fetch(new Request(path))
 
     expect(expectedPath).toHaveBeenFetchedTimes(1)
+  })
+
+  it('should match the url when the default host is defined for wrapito', async () => {
+    const DEFAULT_HOST = '/api'
+    configure({ defaultHost: DEFAULT_HOST})
+
+    const path = `//some-domain.com${DEFAULT_HOST}/some/path/`
+    const expectedPath = '/some/path/'
+
+    await fetch(new Request(path))
+
+    expect(expectedPath).toHaveBeenFetchedTimes(1)
+  })
+
+  it('should match the url when the default host is defined for wrapito and in the expected path', async () => {
+    const DEFAULT_HOST = '/api'
+    configure({ defaultHost: DEFAULT_HOST})
+
+    const path = `//some-domain.com${DEFAULT_HOST}/some/path/`
+    const expectedPath = '/api/some/path/'
+
+    await fetch(new Request(path))
+
+    expect(expectedPath).toHaveBeenFetchedTimes(1)
+    configure({ defaultHost: ''})
   })
 
   it('should check that the path has not been called', async () => {

--- a/tests/assertions/toHaveBeenFetchedTimes.test.js
+++ b/tests/assertions/toHaveBeenFetchedTimes.test.js
@@ -52,6 +52,7 @@ describe('toHaveBeenFetchedTimes', () => {
     await fetch(new Request(path))
 
     expect(expectedPath).toHaveBeenFetchedTimes(1)
+    configure({ defaultHost: ''})
   })
 
   it('should match the url when the default host is defined for wrapito and in the expected path', async () => {


### PR DESCRIPTION
## :camera_flash: Screenshots/Gif/Videos
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->

## :tophat: What?
toHaveBeenFetchedTimes assert with default host
<!--- Describe your changes in detail -->

## :thinking: Why?
As we changed to a more strict match between the paths, we didn't have a test when there is a default host defined for wrapito.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
Adding tests to check the behaviour if the default host is defined in the config.
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->

## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
