### PR TITLE
[Added] Improved log for missing mocks in multipleResponses

### DIFF
--- a/src/mockNetwork.ts
+++ b/src/mockNetwork.ts
@@ -28,12 +28,7 @@ const createDefaultResponse = async () => {
 }
 
 const createResponse = async (mockResponse: Response) => {
-  const {
-    responseBody,
-    status = 200,
-    headers,
-    delay,
-  } = mockResponse
+  const { responseBody, status = 200, headers, delay } = mockResponse
   const response = {
     json: () => Promise.resolve(responseBody),
     status,
@@ -61,20 +56,12 @@ ${chalk.white.bold.bgRed('wrapito')} ${chalk.redBright.bold(
  `)
 }
 
-
-const printPerro = (responses: Response) => {
-      // @ts-ignore
-  const usedResponses = responses.multipleResponses.map((response) => response.responseBody)
-  
-  return console.warn(`${chalk.greenBright(`Missing response in multiple responses`)}
-  ${chalk.greenBright(`respones: ${JSON.stringify(usedResponses)}`)}
-}`)
-}
-
-const mockFetch = async (responses: Response[], request: Request, debug: boolean) => {
-  const responseMatchingRequest = responses.find(
-    getRequestMatcher(request),
-  )
+const mockFetch = async (
+  responses: Response[],
+  request: Request,
+  debug: boolean,
+) => {
+  const responseMatchingRequest = responses.find(getRequestMatcher(request))
 
   if (!responseMatchingRequest) {
     if (debug) {
@@ -94,10 +81,10 @@ const mockFetch = async (responses: Response[], request: Request, debug: boolean
   )
 
   if (!responseNotYetReturned) {
-    printPerro(responseMatchingRequest)
+    printMultipleResponsesWarning(responseMatchingRequest)
     return
   }
-  
+
   responseNotYetReturned.hasBeenReturned = true
   return createResponse(responseNotYetReturned)
 }
@@ -106,6 +93,18 @@ const mockNetwork = (responses: Response[] = [], debug: boolean = false) => {
   const fetch = global.window.fetch
 
   fetch.mockImplementation(request => mockFetch(responses, request, debug))
+}
+
+const printMultipleResponsesWarning = (responses: Response) => {
+  // @ts-ignore
+  const usedResponses = responses.multipleResponses.map(
+    response => response.responseBody,
+  )
+
+  const errorMessage = `Missing response in multiple responses for path ${responses.path} and method ${responses.method}`
+  const formatedErrorMessage = chalk.greenBright(errorMessage)
+
+  console.warn(formatedErrorMessage)
 }
 
 export { mockNetwork }

--- a/src/mockNetwork.ts
+++ b/src/mockNetwork.ts
@@ -61,6 +61,16 @@ ${chalk.white.bold.bgRed('wrapito')} ${chalk.redBright.bold(
  `)
 }
 
+
+const printPerro = (responses: Response) => {
+      // @ts-ignore
+  const usedResponses = responses.multipleResponses.map((response) => response.responseBody)
+  
+  return console.warn(`${chalk.greenBright(`Missing response in multiple responses`)}
+  ${chalk.greenBright(`respones: ${JSON.stringify(usedResponses)}`)}
+}`)
+}
+
 const mockFetch = async (responses: Response[], request: Request, debug: boolean) => {
   const responseMatchingRequest = responses.find(
     getRequestMatcher(request),
@@ -82,8 +92,12 @@ const mockFetch = async (responses: Response[], request: Request, debug: boolean
   const responseNotYetReturned = multipleResponses.find(
     (response: Response) => !response.hasBeenReturned,
   )
-  if (!responseNotYetReturned) return
 
+  if (!responseNotYetReturned) {
+    printPerro(responseMatchingRequest)
+    return
+  }
+  
   responseNotYetReturned.hasBeenReturned = true
   return createResponse(responseNotYetReturned)
 }

--- a/src/mockNetwork.ts
+++ b/src/mockNetwork.ts
@@ -97,9 +97,9 @@ const mockNetwork = (responses: Response[] = [], debug: boolean = false) => {
 
 const printMultipleResponsesWarning = (response: Response) => {
   const errorMessage = `Missing response in the multipleResponses array for path ${response.path} and method ${response.method}.`
-  const formatedErrorMessage = chalk.greenBright(errorMessage)
+  const formattedErrorMessage = chalk.greenBright(errorMessage)
 
-  console.warn(formatedErrorMessage)
+  console.warn(formattedErrorMessage)
 }
 
 export { mockNetwork }

--- a/src/mockNetwork.ts
+++ b/src/mockNetwork.ts
@@ -98,7 +98,7 @@ const mockNetwork = (responses: Response[] = [], debug: boolean = false) => {
 }
 
 const printMultipleResponsesWarning = (response: Response) => {
-  const errorMessage = `Missing response in the multipleResponses array for path ${response.path} and method ${response.method}.`
+  const errorMessage = `🌯 Wrapito:  Missing response in the multipleResponses array for path ${response.path} and method ${response.method}.`
   const formattedErrorMessage = chalk.greenBright(errorMessage)
 
   console.warn(formattedErrorMessage)

--- a/src/mockNetwork.ts
+++ b/src/mockNetwork.ts
@@ -95,13 +95,8 @@ const mockNetwork = (responses: Response[] = [], debug: boolean = false) => {
   fetch.mockImplementation(request => mockFetch(responses, request, debug))
 }
 
-const printMultipleResponsesWarning = (responses: Response) => {
-  // @ts-ignore
-  const usedResponses = responses.multipleResponses.map(
-    response => response.responseBody,
-  )
-
-  const errorMessage = `Missing response in multiple responses for path ${responses.path} and method ${responses.method}`
+const printMultipleResponsesWarning = (response: Response) => {
+  const errorMessage = `Missing response in the multipleResponses array for path ${response.path} and method ${response.method}.`
   const formatedErrorMessage = chalk.greenBright(errorMessage)
 
   console.warn(formatedErrorMessage)

--- a/src/mockNetwork.ts
+++ b/src/mockNetwork.ts
@@ -81,7 +81,9 @@ const mockFetch = async (
   )
 
   if (!responseNotYetReturned) {
-    printMultipleResponsesWarning(responseMatchingRequest)
+    if (debug) {
+      printMultipleResponsesWarning(responseMatchingRequest)
+    }
     return
   }
 

--- a/tests/components.mock.js
+++ b/tests/components.mock.js
@@ -285,6 +285,7 @@ export const MyComponentWithFeedback = () => {
     })
 
     const response = await fetch(request)
+    if(!response) return
     const { name } = await response.json()
     setFeedback(name)
   }

--- a/tests/debugRequests.test.js
+++ b/tests/debugRequests.test.js
@@ -85,7 +85,6 @@ it('should warn about the code making a request that has not being mocked enough
   await screen.findByText('Sam')
 
   fireEvent.click(screen.getByText('save'))
-  const multipleResponsesString = JSON.stringify([{ name: 'Sam' }])
 
   expect(consoleWarn).toHaveBeenCalledWith(
     expect.stringContaining(

--- a/tests/debugRequests.test.js
+++ b/tests/debugRequests.test.js
@@ -76,27 +76,25 @@ it('should warn about the code making a request that has not being mocked enough
       host: 'my-host',
       path: '/path/to/save/',
       method: 'post',
-      multipleResponses: [
-        { responseBody: { name: 'Sam' } },
-      ],
+      multipleResponses: [{ responseBody: { name: 'Sam' } }],
     })
     .debugRequests()
     .mount()
 
-    fireEvent.click(screen.getByText('save'))
-    await screen.findByText('Sam')
+  fireEvent.click(screen.getByText('save'))
+  await screen.findByText('Sam')
 
-    fireEvent.click(screen.getByText('save'))
-    const multipleResponsesString = JSON.stringify([
-      { name: 'Sam' },
-    ])
+  fireEvent.click(screen.getByText('save'))
+  const multipleResponsesString = JSON.stringify([{ name: 'Sam' }])
 
   expect(consoleWarn).toHaveBeenCalledWith(
-    expect.stringContaining('Missing response in multiple responses'),
+    expect.stringContaining(
+      'Missing response in multiple responses for path /path/to/save/ and method post',
+    ),
   )
-  expect(consoleWarn).toHaveBeenCalledWith(
-    expect.stringContaining(`responses: ${multipleResponsesString}`),
-  )  
+  // expect(consoleWarn).toHaveBeenCalledWith(
+  //   expect.stringContaining(`responses: ${multipleResponsesString}`),
+  // )
 })
 
 describe('when no using withNetwork builder', () => {

--- a/tests/debugRequests.test.js
+++ b/tests/debugRequests.test.js
@@ -88,7 +88,7 @@ it('should warn about the code making a request that has not being mocked enough
 
   expect(consoleWarn).toHaveBeenCalledWith(
     expect.stringContaining(
-      'Missing response in the multipleResponses array for path /path/to/save/ and method post.',
+      '🌯 Wrapito:  Missing response in the multipleResponses array for path /path/to/save/ and method post.',
     ),
   )
 })

--- a/tests/debugRequests.test.js
+++ b/tests/debugRequests.test.js
@@ -89,12 +89,9 @@ it('should warn about the code making a request that has not being mocked enough
 
   expect(consoleWarn).toHaveBeenCalledWith(
     expect.stringContaining(
-      'Missing response in multiple responses for path /path/to/save/ and method post',
+      'Missing response in the multipleResponses array for path /path/to/save/ and method post.',
     ),
   )
-  // expect(consoleWarn).toHaveBeenCalledWith(
-  //   expect.stringContaining(`responses: ${multipleResponsesString}`),
-  // )
 })
 
 describe('when no using withNetwork builder', () => {


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Added an improved log for missing mocks in `multipleResponses`

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To improve the debug process when there's any mock missing in the `multipleResponses` expected array

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->
Added test to check that the log is being printed properly
