### PR TITLE
[Added] Handle fetch requests with strings

### DIFF
--- a/src/mockNetwork.ts
+++ b/src/mockNetwork.ts
@@ -94,7 +94,7 @@ const mockFetch = async (
 const mockNetwork = (responses: Response[] = [], debug: boolean = false) => {
   const fetch = global.window.fetch
 
-  fetch.mockImplementation(request => {
+  fetch.mockImplementation((request: WrapRequest) => {
     if (typeof request === 'string') {
       const createdRequest = new Request(request, { method: 'GET' })
       return mockFetch(responses, createdRequest, debug)

--- a/src/mockNetwork.ts
+++ b/src/mockNetwork.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk'
-import { Response, Request } from './models'
+import { Response, WrapRequest } from './models'
 import { getRequestMatcher } from './requestMatcher'
 
 declare global {
@@ -45,7 +45,7 @@ const createResponse = async (mockResponse: Response) => {
   )
 }
 
-const printRequest = (request: Request) => {
+const printRequest = (request: WrapRequest) => {
   return console.warn(`
 ${chalk.white.bold.bgRed('wrapito')} ${chalk.redBright.bold(
     'cannot find any mock matching:',
@@ -58,7 +58,7 @@ ${chalk.white.bold.bgRed('wrapito')} ${chalk.redBright.bold(
 
 const mockFetch = async (
   responses: Response[],
-  request: Request,
+  request: WrapRequest,
   debug: boolean,
 ) => {
   const responseMatchingRequest = responses.find(getRequestMatcher(request))
@@ -94,7 +94,14 @@ const mockFetch = async (
 const mockNetwork = (responses: Response[] = [], debug: boolean = false) => {
   const fetch = global.window.fetch
 
-  fetch.mockImplementation(request => mockFetch(responses, request, debug))
+  fetch.mockImplementation(request => {
+    if (typeof request === 'string') {
+      const createdRequest = new Request(request, { method: 'GET' })
+      return mockFetch(responses, createdRequest, debug)
+    }
+
+    return mockFetch(responses, request, debug)
+  })
 }
 
 const printMultipleResponsesWarning = (response: Response) => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 
 interface WrapRequest extends Request {
-  _bodyInit: string,
+  _bodyInit?: string
 }
 
 interface WrapResponse extends Response {
@@ -61,7 +61,7 @@ interface BrowserHistory extends History {
 }
 
 export {
-  WrapRequest as Request,
+  WrapRequest,
   WrapResponse as Response,
   Config,
   Mount,

--- a/src/requestMatcher.js
+++ b/src/requestMatcher.js
@@ -14,18 +14,27 @@ const getRequestMatcher = request => mockedRequest => {
   const url = host + path
   const isQueryParamsSensitive = !getConfig().handleQueryParams || catchParams
 
-  const hasBody = !!request._bodyInit
-  const requestHash = hash({
-    url: isQueryParamsSensitive ? request.url : request.url.split('?')[0],
-    method: request.method,
-    requestBody: hasBody ? JSON.parse(request._bodyInit) : undefined,
-  })
   const mockedRequestHash = hash({
     url: isQueryParamsSensitive ? url : url.split('?')[0],
     method: method.toUpperCase(),
     requestBody: requestBody,
   })
 
+  if (typeof request === 'string') {
+    const requestHash = hash({
+      url: isQueryParamsSensitive ? request : request.split('?')[0],
+      method: 'GET',
+      requestBody: undefined,
+    })
+    return requestHash === mockedRequestHash
+  }
+
+  const hasBody = !!request._bodyInit
+  const requestHash = hash({
+    url: isQueryParamsSensitive ? request.url : request.url.split('?')[0],
+    method: request.method,
+    requestBody: hasBody ? JSON.parse(request._bodyInit) : undefined,
+  })
   return requestHash === mockedRequestHash
 }
 

--- a/src/requestMatcher.js
+++ b/src/requestMatcher.js
@@ -20,15 +20,6 @@ const getRequestMatcher = request => mockedRequest => {
     requestBody: requestBody,
   })
 
-  if (typeof request === 'string') {
-    const requestHash = hash({
-      url: isQueryParamsSensitive ? request : request.split('?')[0],
-      method: 'GET',
-      requestBody: undefined,
-    })
-    return requestHash === mockedRequestHash
-  }
-
   const hasBody = !!request._bodyInit
   const requestHash = hash({
     url: isQueryParamsSensitive ? request.url : request.url.split('?')[0],

--- a/tests/withNetwork.test.js
+++ b/tests/withNetwork.test.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { wrap, configure } from '../src/index'
 
@@ -186,4 +187,15 @@ it('should not ignore the query params when is specified and it is configured', 
     .mount()
 
   expect(await screen.findByText('quantity: 15')).toBeInTheDocument()
+})
+
+it('should handle fetch requests when a string is passed', async () => {
+  configure({ mount: render })
+  wrap(() => <div></div>).withNetwork([
+    { path: '/foo/bar', responseBody: { foo: 'bar'} }
+  ]).mount()
+
+  const response = await fetch('/foo/bar').then((response) => response.json())
+
+  expect(response).toEqual({ foo: 'bar' })
 })

--- a/tests/withNetwork.test.js
+++ b/tests/withNetwork.test.js
@@ -190,8 +190,10 @@ it('should not ignore the query params when is specified and it is configured', 
 })
 
 it('should handle fetch requests when a string is passed', async () => {
+  const MyComponent = () => null
   configure({ mount: render })
-  wrap(() => <div></div>).withNetwork([
+
+  wrap(MyComponent).withNetwork([
     { path: '/foo/bar', responseBody: { foo: 'bar'} }
   ]).mount()
 


### PR DESCRIPTION
## :camera_flash: Screenshots/Gif/Videos
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->

## :tophat: What?
Handle fetch requests with only strings

```
fetch('/foo/bar')
```
<!--- Describe your changes in detail -->

## :thinking: Why?
The fetch method allows a RequestInfo that could be a Request or a String.
<img width="622" alt="image" src="https://user-images.githubusercontent.com/34795714/211264915-89f487e6-e910-48f2-8f3d-151acac10733.png">
<img width="308" alt="image" src="https://user-images.githubusercontent.com/34795714/211265279-6a7a8efd-c50b-4f47-8176-6b1b146ba02b.png">
)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
Adding tests to check this scenario.
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->

## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
