### PR TITLE
[Added] Support fetch options

### DIFF
--- a/src/mockNetwork.ts
+++ b/src/mockNetwork.ts
@@ -94,12 +94,12 @@ const mockFetch = async (
 const mockNetwork = (responses: Response[] = [], debug: boolean = false) => {
   const fetch = global.window.fetch
 
-  fetch.mockImplementation((request: WrapRequest) => {
-    if (typeof request === 'string') {
-      const createdRequest = new Request(request, { method: 'GET' })
-      return mockFetch(responses, createdRequest, debug)
+  fetch.mockImplementation((input: WrapRequest, init?: RequestInit) => {
+    if (typeof input === 'string') {
+      const request = new Request(input, init)
+      return mockFetch(responses, request, debug)
     }
-
+    const request = input
     return mockFetch(responses, request, debug)
   })
 }

--- a/tests/withNetwork.test.js
+++ b/tests/withNetwork.test.js
@@ -189,7 +189,7 @@ it('should not ignore the query params when is specified and it is configured', 
   expect(await screen.findByText('quantity: 15')).toBeInTheDocument()
 })
 
-it('should handle fetch requests when a string is passed', async () => {
+it('should handle fetch deafult requests when a string is passed', async () => {
   const MyComponent = () => null
   configure({ mount: render })
 
@@ -198,6 +198,19 @@ it('should handle fetch requests when a string is passed', async () => {
   ]).mount()
 
   const response = await fetch('/foo/bar').then((response) => response.json())
+
+  expect(response).toEqual({ foo: 'bar' })
+})
+
+it('should handle fetch requests with option when a string is passed', async () => {
+  const MyComponent = () => null
+  configure({ mount: render })
+
+  wrap(MyComponent).withNetwork([
+    { path: '/foo/bar', method: 'POST', responseBody: { foo: 'bar'} }
+  ]).mount()
+
+  const response = await fetch('/foo/bar', { method: 'POST' }).then((response) => response.json())
 
   expect(response).toEqual({ foo: 'bar' })
 })


### PR DESCRIPTION
## :tophat: What?
Add support to fetch options 

## :thinking: Why?
To support if we have fetch calls without default parameters

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
We added a test to check when call with a POST method we can mock the call
