### PR TITLE
[Added] Manage ko response in fetch

### DIFF
--- a/tests/withNetwork.test.js
+++ b/tests/withNetwork.test.js
@@ -214,3 +214,16 @@ it('should handle fetch requests with option when a string is passed', async () 
 
   expect(response).toEqual({ foo: 'bar' })
 })
+
+it('should handle failed fetch requests', async () => {
+  const MyComponent = () => null
+  configure({ mount: render })
+
+  wrap(MyComponent).withNetwork([
+    { path: '/foo/bar', method: 'POST', responseBody: { foo: 'bar'}, status: 400 }
+  ]).mount()
+
+  const response = await fetch('/foo/bar', { method: 'POST' })
+
+  expect(response.ok).toBeFalsy()
+})


### PR DESCRIPTION
## :tophat: What?
Test ko response in fetch

## :thinking: Why?
It's only to add this one test to coverage this case

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
Adding a new test
