### PR TITLE
[Added] XHR requests support

### DIFF
--- a/config/jest.config.json
+++ b/config/jest.config.json
@@ -18,5 +18,8 @@
   "setupFilesAfterEnv": ["<rootDir>/config/jest.setup.js"],
   "testMatch": [ "<rootDir>/tests/**/?(*.)(test).js" ],
   "moduleFileExtensions": ["js", "json", "ts", "tsx"],
-  "reporters": [ "default", "jest-junit" ]
+  "reporters": [ "default", "jest-junit" ],
+  "moduleNameMapper": {
+    "axios": "axios/dist/node/axios.cjs"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3815,6 +3815,30 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "axios": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.2.tgz",
+      "integrity": "sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "babel-jest": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
@@ -5223,6 +5247,12 @@
       "requires": {
         "locate-path": "^3.0.0"
       }
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true
     },
     "for-each": {
       "version": "0.3.3",
@@ -11398,6 +11428,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "psl": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/history": "^4.7.9",
     "@types/jest": "^26.0.23",
     "@types/react": "^17.0.16",
+    "axios": "^1.2.2",
     "babel-jest": "^24.8.0",
     "jest": "^27.0.4",
     "jest-junit": "^6.4.0",

--- a/src/mockNetwork.ts
+++ b/src/mockNetwork.ts
@@ -11,7 +11,9 @@ declare global {
 
 beforeEach(() => {
   global.window.fetch = jest.fn()
-  global.window.XMLHttpRequest = jest.fn() as jest.MockedFunction<any>
+  global.window.XMLHttpRequest = jest.fn() as jest.MockedClass<
+    typeof global.window.XMLHttpRequest
+  >
 })
 
 afterEach(() => {

--- a/src/wrap.tsx
+++ b/src/wrap.tsx
@@ -13,6 +13,7 @@ import {
 
 beforeEach(() => {
   global.fetch = jest.fn()
+  global.XMLHttpRequest = jest.fn() as jest.MockedFunction<any>
 })
 
 afterEach(() => {

--- a/src/wrap.tsx
+++ b/src/wrap.tsx
@@ -13,7 +13,6 @@ import {
 
 beforeEach(() => {
   global.fetch = jest.fn()
-  global.XMLHttpRequest = jest.fn() as jest.MockedFunction<any>
 })
 
 afterEach(() => {

--- a/tests/components.mock.js
+++ b/tests/components.mock.js
@@ -1,3 +1,4 @@
+import axios from 'axios/lib/axios'
 import React, { Component, Fragment, useState, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { Provider, useDispatch, useSelector } from 'react-redux'
@@ -14,6 +15,14 @@ export const MyComponentWithProps = props => (
 
 export const MyComponentWithPortal = ({ children }) =>
   createPortal(children, document.getElementById('portal-root-id'))
+
+export const Ramon = () => {
+  useEffect(() => {
+    axios.get('/foo/bar')
+  }, [])
+
+  return null
+}
 
 export class MyComponentMakingHttpCalls extends Component {
   state = {

--- a/tests/components.mock.js
+++ b/tests/components.mock.js
@@ -16,14 +16,6 @@ export const MyComponentWithProps = props => (
 export const MyComponentWithPortal = ({ children }) =>
   createPortal(children, document.getElementById('portal-root-id'))
 
-export const Ramon = () => {
-  useEffect(() => {
-    axios.get('/foo/bar')
-  }, [])
-
-  return null
-}
-
 export class MyComponentMakingHttpCalls extends Component {
   state = {
     quantity: 0,

--- a/tests/withNetwork.xhr.test.js
+++ b/tests/withNetwork.xhr.test.js
@@ -3,38 +3,30 @@ import axios from 'axios'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { wrap, configure } from '../src/index'
 
-// it('should have network by default', async () => {
-//   configure({ mount: render })
-//   wrap(() => <div></div>).withNetwork([
-//     { path: '/foo/bar', responseBody: { foo: 'bar' }}
-//   ]).mount()
+it('should have network by default', async () => {
+  configure({ mount: render })
+  wrap(() => <div></div>).withNetwork([
+    { path: '/foo/bar', responseBody: { foo: 'bar' }}
+  ]).mount()
 
-//   let response
-//   let xhr = new XMLHttpRequest()
-//   xhr.open('GET', '/foo/bar')
-//   xhr.onload = function() {
-//     if (xhr.status === 200) {
-//       response = { foo: 'bar' }
-//     }
-//   }
-//   xhr.send()
+  let xhr = new XMLHttpRequest()
+  xhr.open('GET', '/foo/bar')
+  xhr.send()
 
-//   expect(response).toEqual({ foo: 'bar' })
-// })
+  expect(xhr.response).toEqual({ foo: 'bar' })
+  expect(xhr.status).toEqual(200)
+})
 
-fit('should have network by default', async () => {
+it('should have network by default', async () => {
   configure({ mount: render })
   wrap(() => <div></div>).withNetwork([
     { path: '/bar/foo', responseBody: { bar: 'foo' }},
     { path: '/foo/bar', responseBody: { foo: 'bar' }},
-    // { path: '/foo/ramon', method: 'POST', requestBody: { foo: 'bar' }, responseBody: { foo: 'ramon' }},
   ]).mount()
 
   const firstResponse = await axios.get('/foo/bar', { responseType: 'application/json' })
   const secondResponse = await axios.get('/bar/foo', { responseType: 'application/json' })
-  // const ramon = await axios.post('/foo/ramon', { foo: 'bar' }, { responseType: 'application/json' })
 
   expect(firstResponse.data).toEqual({ foo: 'bar' })
   expect(secondResponse.data).toEqual({ bar: 'foo' })
-  // expect(ramon.data).toEqual({ foo: 'ramon' })
 })

--- a/tests/withNetwork.xhr.test.js
+++ b/tests/withNetwork.xhr.test.js
@@ -8,13 +8,15 @@ it('should have network by default', async () => {
   wrap(() => <div></div>).withNetwork([
     { path: '/foo/bar', responseBody: { foo: 'bar' }}
   ]).mount()
-
+  const mockedFn = jest.fn()
   let xhr = new XMLHttpRequest()
   xhr.open('GET', '/foo/bar')
+  xhr.onreadystatechange = mockedFn
   xhr.send()
 
   expect(xhr.response).toEqual({ foo: 'bar' })
   expect(xhr.status).toEqual(200)
+  expect(mockedFn).toHaveBeenCalled()
 })
 
 it('should have network by default', async () => {
@@ -29,4 +31,19 @@ it('should have network by default', async () => {
 
   expect(firstResponse.data).toEqual({ foo: 'bar' })
   expect(secondResponse.data).toEqual({ bar: 'foo' })
+})
+
+it('should handle failed axios requests', async () => {
+  configure({ mount: render })
+  wrap(() => <div></div>).withNetwork([
+    { path: '/bar/foo', responseBody: { bar: 'foo' }, status: 400},
+  ]).mount()
+
+  try {
+    await axios.get('/bar/foo', { responseType: 'application/json' })
+  } catch (error) {
+    expect(error.name).toBe('AxiosError')
+    expect(error.message).toBe('Request failed with status code 400')
+    expect(error.response.data).toEqual({ bar: 'foo' })
+  }
 })

--- a/tests/withNetwork.xhr.test.js
+++ b/tests/withNetwork.xhr.test.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import axios from 'axios'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { wrap, configure } from '../src/index'
+
+// it('should have network by default', async () => {
+//   configure({ mount: render })
+//   wrap(() => <div></div>).withNetwork([
+//     { path: '/foo/bar', responseBody: { foo: 'bar' }}
+//   ]).mount()
+
+//   let response
+//   let xhr = new XMLHttpRequest()
+//   xhr.open('GET', '/foo/bar')
+//   xhr.onload = function() {
+//     if (xhr.status === 200) {
+//       response = { foo: 'bar' }
+//     }
+//   }
+//   xhr.send()
+
+//   expect(response).toEqual({ foo: 'bar' })
+// })
+
+fit('should have network by default', async () => {
+  configure({ mount: render })
+  wrap(() => <div></div>).withNetwork([
+    { path: '/bar/foo', responseBody: { bar: 'foo' }},
+    { path: '/foo/bar', responseBody: { foo: 'bar' }},
+    // { path: '/foo/ramon', method: 'POST', requestBody: { foo: 'bar' }, responseBody: { foo: 'ramon' }},
+  ]).mount()
+
+  const firstResponse = await axios.get('/foo/bar', { responseType: 'application/json' })
+  const secondResponse = await axios.get('/bar/foo', { responseType: 'application/json' })
+  // const ramon = await axios.post('/foo/ramon', { foo: 'bar' }, { responseType: 'application/json' })
+
+  expect(firstResponse.data).toEqual({ foo: 'bar' })
+  expect(secondResponse.data).toEqual({ bar: 'foo' })
+  // expect(ramon.data).toEqual({ foo: 'ramon' })
+})


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Added XHR requests support

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
So Wrapito can be used to mock axios requests

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->
Added tests to check that:

- XHR requests are properly supported
- Axios resolved requests can be mocked
- Axios rejected requests can be mocked
