### PR TITLE
[Added] Host options for toHaveBeenFetched method

### DIFF
--- a/src/assertions/fetch.js
+++ b/src/assertions/fetch.js
@@ -16,14 +16,18 @@ const findRequestsByPath = (expectedPath, options) =>
     const url = getUrl(call)
     const callURL = new URL(url, defaultHost)
     const path = getPath(options?.host, expectedPath, defaultHost)
-    const expectedURL = new URL(path, defaultHost)
+    const expectedHost = options?.host || defaultHost
+    const expectedURL = new URL(path, expectedHost)
     const matchPathName = callURL.pathname === expectedURL.pathname
     const matchSearchParams = callURL.search === expectedURL.search
 
+    const matchHost = callURL.host === expectedURL.host
     if (expectedURL.search) {
       return matchPathName && matchSearchParams
     }
-
+    if (options?.host) {
+      return matchPathName && matchHost
+    }
     return matchPathName
   })
 
@@ -85,8 +89,8 @@ const toHaveBeenFetchedWith = (path, options) => {
 const toHaveBeenFetched = (path, options) => {
   const requests = findRequestsByPath(path, options)
   return !requests.length
-    ? emptyErrorMessage(path)
-    : haveBeenFetchedSuccessMessage(path)
+    ? emptyErrorMessage(path, options)
+    : haveBeenFetchedSuccessMessage(path, options)
 }
 
 const toHaveBeenFetchedTimes = (path, expectedLength, options) => {

--- a/src/assertions/fetch.js
+++ b/src/assertions/fetch.js
@@ -11,15 +11,12 @@ import {
 } from './messages'
 
 const findRequestsByPath = (expectedPath, options) =>
-  fetch.mock.calls.filter(call => {
+  fetch.mock.calls.filter(([call]) => {
     const defaultHost = getConfig().defaultHost || 'https://default.com'
-    const url = call[0] instanceof Request ? call[0].url : call[0]
+    const url = getUrl(call)
     const callURL = new URL(url, defaultHost)
-    const host = options?.host || ''
-    const finalExpectedPath = expectedPath.includes(defaultHost)
-      ? expectedPath
-      : host + expectedPath
-    const expectedURL = new URL(finalExpectedPath, defaultHost)
+    const path = getPath(options?.host, expectedPath, defaultHost)
+    const expectedURL = new URL(path, defaultHost)
     const matchPathName = callURL.pathname === expectedURL.pathname
     const matchSearchParams = callURL.search === expectedURL.search
 
@@ -30,6 +27,10 @@ const findRequestsByPath = (expectedPath, options) =>
     return matchPathName
   })
 
+const getPath = (host = '', expectedPath, defaultHost) =>
+  expectedPath.includes(defaultHost) ? expectedPath : host + expectedPath
+
+const getUrl = call => (call instanceof Request ? call.url : call)
 const getRequestsMethods = requests =>
   requests.map(request => request[0]?.method)
 

--- a/src/assertions/fetch.js
+++ b/src/assertions/fetch.js
@@ -88,8 +88,8 @@ const toHaveBeenFetched = (path, options) => {
     : haveBeenFetchedSuccessMessage(path)
 }
 
-const toHaveBeenFetchedTimes = (path, expectedLength) => {
-  const requests = findRequestsByPath(path)
+const toHaveBeenFetchedTimes = (path, expectedLength, options) => {
+  const requests = findRequestsByPath(path, options)
   return requests.length !== expectedLength
     ? fetchLengthErrorMessage(path, expectedLength, requests.length)
     : successMessage()

--- a/src/assertions/messages.js
+++ b/src/assertions/messages.js
@@ -46,7 +46,7 @@ const successMessage = () => ({
 
 const haveBeenFetchedSuccessMessage = (path, options) => {
   const message = options?.host
-    ? `🌯 Wrapito: ${path} is called with host ${options.host}`
+    ? `🌯 Wrapito: ${options.host}${path} is called`
     : `🌯 Wrapito: ${path} is called`
   return {
     pass: true,

--- a/src/assertions/messages.js
+++ b/src/assertions/messages.js
@@ -1,20 +1,26 @@
 import { green, red } from 'chalk'
 
-const emptyErrorMessage = path => ({
-  pass: false,
-  message: () => `🌯 Wrapito: ${ path } ain't got called`,
-})
+const emptyErrorMessage = (path, options) => {
+  const message = options?.host
+    ? `🌯 Wrapito: ${options?.host}${path} ain't got called`
+    : `🌯 Wrapito: ${path} ain't got called`
+
+  return {
+    pass: false,
+    message: () => message,
+  }
+}
 
 const fetchLengthErrorMessage = (path, expectLength, currentLength) => ({
   pass: false,
   message: () =>
-    `🌯 Wrapito: ${ path } is called ${ currentLength } times, you expected ${ expectLength } times`,
+    `🌯 Wrapito: ${path} is called ${currentLength} times, you expected ${expectLength} times`,
 })
 
 const methodDoesNotMatchErrorMessage = (expected, received) => ({
   pass: false,
   message: () =>
-    `🌯 Wrapito: Fetch method does not match, expected ${ expected } received ${ received }`,
+    `🌯 Wrapito: Fetch method does not match, expected ${expected} received ${received}`,
 })
 
 const bodyDoesNotMatchErrorMessage = (expected, received) => ({
@@ -22,15 +28,15 @@ const bodyDoesNotMatchErrorMessage = (expected, received) => ({
   message: () =>
     `🌯 Wrapito: Fetch body does not match.
 Expected:
-${ green(JSON.stringify(expected, null, ' ')) }
+${green(JSON.stringify(expected, null, ' '))}
 
 Received:
-${ red(JSON.stringify(received, null, ' ')) }`,
+${red(JSON.stringify(received, null, ' '))}`,
 })
 
 const doesNotHaveBodyErrorMessage = () => ({
   pass: false,
-  message: () => '🌯 Wrapito: Unable to find body.'
+  message: () => '🌯 Wrapito: Unable to find body.',
 })
 
 const successMessage = () => ({
@@ -38,10 +44,15 @@ const successMessage = () => ({
   message: () => undefined,
 })
 
-const haveBeenFetchedSuccessMessage = (path) => ({
-  pass: true,
-  message: () => `🌯 Wrapito: ${path} is called`,
-})
+const haveBeenFetchedSuccessMessage = (path, options) => {
+  const message = options?.host
+    ? `🌯 Wrapito: ${path} is called with host ${options.host}`
+    : `🌯 Wrapito: ${path} is called`
+  return {
+    pass: true,
+    message: () => message,
+  }
+}
 
 export {
   emptyErrorMessage,

--- a/tests/assertions/toHaveBeenFetched.test.js
+++ b/tests/assertions/toHaveBeenFetched.test.js
@@ -1,4 +1,4 @@
-import { assertions } from '../../src'
+import { assertions, configure } from '../../src'
 
 expect.extend(assertions)
 
@@ -23,5 +23,34 @@ describe('toHaveBeenFetched', () => {
 
     expect(message()).toBe("🌯 Wrapito: /some/unknown ain't got called")
     expect(expectedPath).not.toHaveBeenFetched()
+  })
+
+  fit('should check that the path has been called without new Request', async () => {
+    const path = '//some-domain.com/some/path/'
+    const expectedPath = '/some/path/'
+
+    await fetch(path)
+    const { message } = await assertions.toHaveBeenFetched(expectedPath)
+
+    expect(message()).toBe('🌯 Wrapito: /some/path/ is called')
+    expect(expectedPath).toHaveBeenFetched()
+  })
+
+  fit('should check that the path has been called with custom host', async () => {
+    const path = '//some-domain.com/some/path/'
+    const expectedPath = '/some/path/'
+    configure({
+      defaultHost: 'https://some-domain.com',
+    })
+    const options = { host: 'https://some-domain.com' }
+    await fetch(new Request(path))
+    const { message } = await assertions.toHaveBeenFetched(
+      expectedPath,
+      options,
+    )
+
+    expect(message()).toBe('🌯 Wrapito: /some/path/ is called')
+    expect(expectedPath).toHaveBeenFetched(options)
+    configure({ defaultHost: '' })
   })
 })

--- a/tests/assertions/toHaveBeenFetched.test.js
+++ b/tests/assertions/toHaveBeenFetched.test.js
@@ -37,16 +37,42 @@ describe('toHaveBeenFetched', () => {
   })
 
   it('should check that the path has been called with custom host', async () => {
-    const path = '//some-perro.com/some/path/'
+    const path = '//other-domain.com/some/path/'
     const expectedPath = '/some/path/'
+    const host = 'https://other-domain.com'
     configure({
       defaultHost: 'https://some-domain.com',
     })
     await fetch(new Request(path))
-    const { message } = await assertions.toHaveBeenFetched(path)
+    const { message } = await assertions.toHaveBeenFetched(expectedPath, {
+      host,
+    })
 
-    expect(message()).toBe('🌯 Wrapito: /some/path/ is called')
-    expect(expectedPath).toHaveBeenFetched()
+    expect(message()).toBe(
+      '🌯 Wrapito: /some/path/ is called with host https://other-domain.com',
+    )
+    expect(expectedPath).toHaveBeenFetched({ host })
+    configure({ defaultHost: '' })
+  })
+
+  it('should check that the path has not been called with custom host', async () => {
+    const path = '//some-domain.com/some/path/'
+    const expectedPath = '/some/path/'
+    const host = 'https://other-domain.com'
+    configure({
+      defaultHost: 'https://some-domain.com',
+    })
+    await fetch(new Request(path))
+    const { message } = await assertions.toHaveBeenFetched(expectedPath, {
+      host,
+    })
+
+    expect(message()).toBe(
+      `🌯 Wrapito: ${host}${expectedPath} ain't got called`,
+    )
+    expect(expectedPath).not.toHaveBeenFetched({
+      host,
+    })
     configure({ defaultHost: '' })
   })
 })

--- a/tests/assertions/toHaveBeenFetched.test.js
+++ b/tests/assertions/toHaveBeenFetched.test.js
@@ -37,20 +37,16 @@ describe('toHaveBeenFetched', () => {
   })
 
   it('should check that the path has been called with custom host', async () => {
-    const path = '//some-domain.com/some/path/'
+    const path = '//some-perro.com/some/path/'
     const expectedPath = '/some/path/'
     configure({
       defaultHost: 'https://some-domain.com',
     })
-    const options = { host: 'https://some-domain.com' }
     await fetch(new Request(path))
-    const { message } = await assertions.toHaveBeenFetched(
-      expectedPath,
-      options,
-    )
+    const { message } = await assertions.toHaveBeenFetched(path)
 
     expect(message()).toBe('🌯 Wrapito: /some/path/ is called')
-    expect(expectedPath).toHaveBeenFetched(options)
+    expect(expectedPath).toHaveBeenFetched()
     configure({ defaultHost: '' })
   })
 })

--- a/tests/assertions/toHaveBeenFetched.test.js
+++ b/tests/assertions/toHaveBeenFetched.test.js
@@ -49,7 +49,7 @@ describe('toHaveBeenFetched', () => {
     })
 
     expect(message()).toBe(
-      '🌯 Wrapito: /some/path/ is called with host https://other-domain.com',
+      '🌯 Wrapito: https://other-domain.com/some/path/ is called',
     )
     expect(expectedPath).toHaveBeenFetched({ host })
     configure({ defaultHost: '' })

--- a/tests/assertions/toHaveBeenFetched.test.js
+++ b/tests/assertions/toHaveBeenFetched.test.js
@@ -25,7 +25,7 @@ describe('toHaveBeenFetched', () => {
     expect(expectedPath).not.toHaveBeenFetched()
   })
 
-  fit('should check that the path has been called without new Request', async () => {
+  it('should check that the path has been called without new Request', async () => {
     const path = '//some-domain.com/some/path/'
     const expectedPath = '/some/path/'
 
@@ -36,7 +36,7 @@ describe('toHaveBeenFetched', () => {
     expect(expectedPath).toHaveBeenFetched()
   })
 
-  fit('should check that the path has been called with custom host', async () => {
+  it('should check that the path has been called with custom host', async () => {
     const path = '//some-domain.com/some/path/'
     const expectedPath = '/some/path/'
     configure({

--- a/tests/assertions/toHaveBeenFetchedTimes.test.js
+++ b/tests/assertions/toHaveBeenFetchedTimes.test.js
@@ -43,29 +43,31 @@ describe('toHaveBeenFetchedTimes', () => {
   })
 
   it('should match the url when the default host is defined for wrapito', async () => {
-    const DEFAULT_HOST = '/api'
-    configure({ defaultHost: DEFAULT_HOST})
+    const DEFAULT_HOST = 'https://some-domain.com/api'
+    configure({ defaultHost: DEFAULT_HOST })
+    const options = { host: 'https://some-domain.com/api' }
 
-    const path = `//some-domain.com${DEFAULT_HOST}/some/path/`
+    const path = `${DEFAULT_HOST}/some/path/`
     const expectedPath = '/some/path/'
 
     await fetch(new Request(path))
 
-    expect(expectedPath).toHaveBeenFetchedTimes(1)
-    configure({ defaultHost: ''})
+    expect(expectedPath).toHaveBeenFetchedTimes(1, options)
+    configure({ defaultHost: '' })
   })
 
   it('should match the url when the default host is defined for wrapito and in the expected path', async () => {
-    const DEFAULT_HOST = '/api'
-    configure({ defaultHost: DEFAULT_HOST})
+    const DEFAULT_HOST = 'https://some-domain.com'
+    configure({ defaultHost: DEFAULT_HOST })
+    const options = { host: 'https://some-domain.com' }
 
-    const path = `//some-domain.com${DEFAULT_HOST}/some/path/`
+    const path = `${DEFAULT_HOST}/api/some/path/`
     const expectedPath = '/api/some/path/'
 
     await fetch(new Request(path))
 
-    expect(expectedPath).toHaveBeenFetchedTimes(1)
-    configure({ defaultHost: ''})
+    expect(expectedPath).toHaveBeenFetchedTimes(1, options)
+    configure({ defaultHost: '' })
   })
 
   it('should check that the path has not been called', async () => {

--- a/tests/assertions/toHaveBeenFetchedWith.test.js
+++ b/tests/assertions/toHaveBeenFetchedWith.test.js
@@ -30,15 +30,15 @@ describe('toHaveBeenFetchedWith', () => {
   })
 
   describe('request body', () => {
-  it('should check that the request has body', async () => {
-    const path = '//some-domain.com/some/path/'
+    it('should check that the request has body', async () => {
+      const path = '//some-domain.com/some/path/'
 
-    await fetch(new Request(path))
-    const { message, pass } = await assertions.toHaveBeenFetchedWith(path)
+      await fetch(new Request(path))
+      const { message, pass } = await assertions.toHaveBeenFetchedWith(path)
 
-    expect(message()).toBe('🌯 Wrapito: Unable to find body.')
-    expect(pass).toBe(false)
-  })
+      expect(message()).toBe('🌯 Wrapito: Unable to find body.')
+      expect(pass).toBe(false)
+    })
 
     it('should check that the path has been called with the supplied body', async () => {
       const path = '//some-domain.com/some/path/'
@@ -153,10 +153,10 @@ describe('toHaveBeenFetchedWith', () => {
       expect(message()).toBe(
         `🌯 Wrapito: Fetch body does not match.
 Expected:
-${ green(JSON.stringify(expectedBody, null, ' ')) }
+${green(JSON.stringify(expectedBody, null, ' '))}
 
 Received:
-${ red(JSON.stringify([receivedBody], null, ' ')) }`,
+${red(JSON.stringify([receivedBody], null, ' '))}`,
       )
       expect(path).not.toHaveBeenFetchedWith({
         body: expectedBody,
@@ -167,7 +167,7 @@ ${ red(JSON.stringify([receivedBody], null, ' ')) }`,
   describe('request method', () => {
     it('should check that the path has been called with the supplied method', async () => {
       const path = '//some-domain.com/some/path/'
-      const body = {method: 'POST'}
+      const body = { method: 'POST' }
 
       await fetch(new Request(path, body))
       const { message } = await assertions.toHaveBeenFetchedWith(path, {
@@ -245,10 +245,12 @@ ${ red(JSON.stringify([receivedBody], null, ' ')) }`,
       const request = new Request(path, { method: 'POST' })
       await fetch(request)
 
-      const { message } = await assertions.toHaveBeenFetchedWith(path, { body: {}})
+      const { message } = await assertions.toHaveBeenFetchedWith(path, {
+        body: {},
+      })
 
       expect(message()).toBeUndefined()
-      expect(path).toHaveBeenFetchedWith({ body: {}})
+      expect(path).toHaveBeenFetchedWith({ body: {} })
     })
   })
 })


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Added host options for toHaveBeenFetched method
## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To check that a path has been called when using an external host. 
## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->
Calls with different host that configure host
## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
 