### PR TITLE
[Fixed] Fetch: Handle defaultHosts without protocol

### DIFF
--- a/src/assertions/fetch.js
+++ b/src/assertions/fetch.js
@@ -12,8 +12,8 @@ import {
 
 const findRequestsByPath = (expectedPath, options) =>
   fetch.mock.calls.filter(([call]) => {
-    const defaultHost = getConfig().defaultHost || 'https://default.com'
     const url = getUrl(call)
+    const defaultHost = getDefaultHost()
     const callURL = new URL(url, defaultHost)
     const path = getPath(options?.host, expectedPath, defaultHost)
     const expectedHost = options?.host || defaultHost
@@ -30,6 +30,11 @@ const findRequestsByPath = (expectedPath, options) =>
     }
     return matchPathName
   })
+
+const getDefaultHost = () => {
+  const configuredHost = getConfig().defaultHost
+  return configuredHost?.includes('http') ? configuredHost : 'https://default.com'
+}
 
 const getPath = (host = '', expectedPath, defaultHost) =>
   expectedPath.includes(defaultHost) ? expectedPath : host + expectedPath

--- a/tests/assertions/toHaveBeenFetched.test.js
+++ b/tests/assertions/toHaveBeenFetched.test.js
@@ -55,6 +55,25 @@ describe('toHaveBeenFetched', () => {
     configure({ defaultHost: '' })
   })
 
+  it('should check that the path has been called with custom host without protocol', async () => {
+    const path = '//other-domain.com/some/path/'
+    const expectedPath = '/some/path/'
+    const host = 'https://other-domain.com'
+    configure({
+      defaultHost: '/some-domain.com',
+    })
+    await fetch(new Request(path))
+    const { message } = await assertions.toHaveBeenFetched(expectedPath, {
+      host,
+    })
+
+    expect(message()).toBe(
+      '🌯 Wrapito: https://other-domain.com/some/path/ is called',
+    )
+    expect(expectedPath).toHaveBeenFetched({ host })
+    configure({ defaultHost: '' })
+  })
+
   it('should check that the path has not been called with custom host', async () => {
     const path = '//some-domain.com/some/path/'
     const expectedPath = '/some/path/'


### PR DESCRIPTION
## :camera_flash: Screenshots/Gif/Videos
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->
<img width="566" alt="image" src="https://user-images.githubusercontent.com/33147606/228501188-c2ba7c51-bddb-4cc4-a0bf-f04c12218412.png">

## :tophat: What?
<!--- Describe your changes in detail -->
Handle defaultHosts without protocol when asserting fetches. 

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order to prevent a breaking change: when building a new URL instance, projects with a defaultHost without protocol would trigger an error

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->
Added test to check that the assertion works when the defaultHost doesn't have protocol

## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
