### PR TITLE
[Removed] Dependency of react version

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,19 +1,8 @@
-import { render } from 'react-dom'
-
-import type { Component, Config, RenderResult } from './models'
-
-const mount = (Component: Component): RenderResult => {
-  const rootNode = document.body.appendChild(document.createElement('div'))
-
-  render(Component, rootNode)
-
-  return rootNode
-}
+import type { Config } from './models'
 
 let config: Config = {
   defaultHost: '',
   extend: {},
-  mount,
   changeRoute: (path: string) => window.history.replaceState(null, '', path),
 }
 
@@ -26,4 +15,4 @@ function configure(newConfig: Partial<Config>) {
 
 const getConfig = (): Config => ({ ...config })
 
-export { configure, getConfig, Config, mount }
+export { configure, getConfig, Config }

--- a/src/models.ts
+++ b/src/models.ts
@@ -80,7 +80,7 @@ export type Mount = (component: Component) => RenderResult
 
 export interface Config {
   defaultHost: string
-  mount: Mount
+  mount?: Mount
   extend: Extensions
   changeRoute: (path: string) => void
   history?: BrowserHistory

--- a/src/wrap.tsx
+++ b/src/wrap.tsx
@@ -141,7 +141,7 @@ const getMount = () => {
 
   mockNetwork(responses, debug)
 
-  return mount(<C {...props} />)
+  return mount?.(<C {...props} />)
 }
 
 const setupPortal = (portalRootId: string) => {

--- a/tests/lib/wrap.test.ts
+++ b/tests/lib/wrap.test.ts
@@ -39,16 +39,6 @@ it('should have props', () => {
   expect(container).toHaveTextContent(props.foo)
 })
 
-it('should have an element where to place a portal defined in the config', () => {
-  const childrenText = 'I am a portal'
-  const props = { children: childrenText }
-  configure({ portal: 'portal-root-id' })
-
-  wrap(MyComponentWithPortal).withProps(props).mount()
-
-  expect(document.body).toHaveTextContent(childrenText)
-})
-
 it('should have unique portals', () => {
   configure({ mount: render, portal: portalRootId })
   const childrenText = 'I am a portal'
@@ -58,13 +48,6 @@ it('should have unique portals', () => {
   wrap(MyComponentWithPortal).withProps(props).mount()
 
   expect(document.querySelectorAll(`#${portalRootId}`)).toHaveLength(1)
-})
-
-it('should use the default mount', () => {
-  const expectedText = 'Foo'
-  const { textContent } = wrap(MyComponent).mount()
-
-  expect(textContent).toBe(expectedText)
 })
 
 it('should use a custom mount', () => {


### PR DESCRIPTION
## :camera_flash: Screenshots/Gif/Videos
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->

## :tophat: What?
Spike if we can make wrapito more agnostic and remove dependency from react version.

## :thinking: Why?
Currently we stuck in the version 18 of react in all the projects because wrapito uses a deprecated way of rendering. But we saw that the default rendering is not working for some amount of versions, and in all the projects we use the render method from react-testing-library.

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
Removed tests that require using the default render.

## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
