### PR TITLE
[Added] Host to have been fetched matcher

### DIFF
--- a/src/matchers/matchers.ts
+++ b/src/matchers/matchers.ts
@@ -4,6 +4,7 @@ import {
   fetchLengthErrorMessage,
   methodDoesNotMatchErrorMessage,
   bodyDoesNotMatchErrorMessage,
+  hostDoesNotMatchErrorMessage,
   doesNotHaveBodyErrorMessage,
   successMessage,
   haveBeenFetchedSuccessMessage,
@@ -16,6 +17,8 @@ import {
   getRequestsBodies,
   bodyDoesNotMatch,
   methodDoesNotMatch,
+  getRequestsHosts,
+  hostDoesNotMatch,
 } from '../utils'
 
 const toHaveBeenFetchedWith = (path: string, options?: RequestOptions) => {
@@ -37,10 +40,18 @@ const toHaveBeenFetchedWith = (path: string, options?: RequestOptions) => {
 
   const receivedRequestsBodies = getRequestsBodies(targetRequests)
   const expectedBody = options?.body
+
   if (!expectedBody) return doesNotHaveBodyErrorMessage()
 
   if (bodyDoesNotMatch(expectedBody, receivedRequestsBodies)) {
     return bodyDoesNotMatchErrorMessage(expectedBody, receivedRequestsBodies)
+  }
+
+  const receivedRequestsHosts = getRequestsHosts(targetRequests)
+  const expectedHost = options?.host
+
+  if (expectedHost && hostDoesNotMatch(expectedHost, receivedRequestsHosts)) {
+    return hostDoesNotMatchErrorMessage(expectedHost, receivedRequestsHosts)
   }
 
   return successMessage()

--- a/src/matchers/messages.ts
+++ b/src/matchers/messages.ts
@@ -51,6 +51,21 @@ ${diffs}`,
   }
 }
 
+const hostDoesNotMatchErrorMessage = (
+  expected: string,
+  receivedRequestsHosts: Array<string>,
+) => {
+  const receivedDiff = receivedRequestsHosts.find(
+    received => expected !== received,
+  )
+
+  return {
+    pass: false,
+    message: () =>
+      `🌯 Wrapito: Host request does not match, expected ${expected} received ${receivedDiff}`,
+  }
+}
+
 const doesNotHaveBodyErrorMessage = () => ({
   pass: false,
   message: () => '🌯 Wrapito: Unable to find body.',
@@ -79,6 +94,7 @@ export {
   fetchLengthErrorMessage,
   methodDoesNotMatchErrorMessage,
   bodyDoesNotMatchErrorMessage,
+  hostDoesNotMatchErrorMessage,
   doesNotHaveBodyErrorMessage,
   successMessage,
   haveBeenFetchedSuccessMessage,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -61,6 +61,12 @@ export const getRequestsBodies = (requests: Array<Array<unknown>>) =>
       return JSON.parse(request._bodyInit)
     })
 
+export const getRequestsHosts = (requests: Array<Array<unknown>>) =>
+  requests
+    .flat(1)
+    .filter(isRequest)
+    .map(request => new URL(request.url, getDefaultHost()).hostname)
+
 export const methodDoesNotMatch = (
   expectedMethod: string | undefined,
   receivedRequestsMethods: Array<string | undefined>,
@@ -73,6 +79,17 @@ export const bodyDoesNotMatch = (
   const anyRequestMatch = receivedRequestsBodies
     .map(request => deepEqual(expectedBody, request))
     .every(requestCompare => requestCompare === false)
+
+  return anyRequestMatch
+}
+
+export const hostDoesNotMatch = (
+  expectedHost: string,
+  receivedRequestsHosts: Array<string>,
+) => {
+  const anyRequestMatch = receivedRequestsHosts.every(
+    requestHost => requestHost !== expectedHost,
+  )
 
   return anyRequestMatch
 }

--- a/tests/matchers/toHaveBeenFetchedWith.test.ts
+++ b/tests/matchers/toHaveBeenFetchedWith.test.ts
@@ -254,4 +254,44 @@ ${diff(expectedBody, receivedBody)}`,
       expect(path).toHaveBeenFetchedWith({ body: {} })
     })
   })
+
+  describe('request host', () => {
+    it('should check that the path has been called with the supplied host', async () => {
+      const path = '//some-domain.com/some/path/'
+      const expectedHost = 'some-domain.com'
+      const body = {}
+
+      await fetch(new Request(path, body))
+      const { message } = matchers.toHaveBeenFetchedWith(path, {
+        body: {},
+        host: 'some-domain.com',
+      })
+
+      expect(message()).toBe('Test passing')
+      expect(path).toHaveBeenFetchedWith({
+        body: {},
+        host: expectedHost,
+      })
+    })
+
+    it('should check that the path has not been called with the supplied host', async () => {
+      const path = '//some-domain.com/some/path/'
+      const expectedHost = 'another-domain.com'
+      const request = new Request(path)
+      await fetch(request)
+
+      const { message } = matchers.toHaveBeenFetchedWith(path, {
+        body: {},
+        host: 'another-domain.com',
+      })
+
+      expect(message()).toBe(
+        '🌯 Wrapito: Host request does not match, expected another-domain.com received some-domain.com',
+      )
+      expect(path).not.toHaveBeenFetchedWith({
+        body: {},
+        host: expectedHost,
+      })
+    })
+  })
 })


### PR DESCRIPTION
## :tophat: What?
Add host to have been fetched matcher

## :thinking: Why?
To check also this value

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
We added new test to check this feature

## :speaking_head: Comments
We have to check this to change in  my project one endpoint from one service to another one
