### PR TITLE
add property portals to wrapito config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wrapito",
-  "version": "10.0.0",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wrapito",
-      "version": "10.0.0",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/src/models.ts
+++ b/src/models.ts
@@ -85,6 +85,7 @@ export interface Config {
   changeRoute: (path: string) => void
   history?: BrowserHistory
   portal?: string
+  portals?: string[]
   handleQueryParams?: boolean
 }
 

--- a/src/wrap.tsx
+++ b/src/wrap.tsx
@@ -115,7 +115,7 @@ const debugRequests = () => {
 }
 
 const getMount = () => {
-  const { portal, changeRoute, history, mount } = getConfig()
+  const { portal, portals, changeRoute, history, mount } = getConfig()
   const { Component, props, responses, path, hasPath, debug, historyState } =
     getOptions()
 
@@ -123,6 +123,10 @@ const getMount = () => {
 
   if (portal) {
     setupPortal(portal)
+  }
+
+  if (portals) {
+    setupPortals(portals)
   }
 
   if (hasPath && history) {
@@ -152,6 +156,12 @@ const setupPortal = (portalRootId: string) => {
   const portalRoot = document.createElement('div')
   portalRoot.setAttribute('id', portalRootId)
   document.body.appendChild(portalRoot)
+}
+
+const setupPortals = (portalRootIds: string[]) => {
+  portalRootIds.forEach(portal => {
+    setupPortal(portal)
+  })
 }
 
 export { wrap }

--- a/tests/components.mock.jsx
+++ b/tests/components.mock.jsx
@@ -21,6 +21,12 @@ export const MyComponentWithProps = props => (
 export const MyComponentWithPortal = ({ children }) =>
   createPortal(children, document.getElementById('portal-root-id'))
 
+export const MyComponentWithPortals = ({ children, portalIds }) => {
+  return portalIds.map((portalId, index) => {
+    return createPortal(children[index], document.getElementById(portalId))
+  })
+}
+
 export class MyComponentMakingHttpCalls extends Component {
   state = {
     quantity: 0,

--- a/tests/lib/wrap.test.ts
+++ b/tests/lib/wrap.test.ts
@@ -5,6 +5,7 @@ import {
   MyComponent,
   MyComponentWithProps,
   MyComponentWithPortal,
+  MyComponentWithPortals,
 } from '../components.mock'
 import { it, expect, afterEach } from 'vitest'
 
@@ -47,6 +48,20 @@ it('should have an element where to place a portal defined in the config', () =>
   wrap(MyComponentWithPortal).withProps(props).mount()
 
   expect(document.body).toHaveTextContent(childrenText)
+})
+
+it('should have elements where to place portals defined in the config', () => {
+  const childrenTexts = ['I am a portal 1', 'I am a portal 2']
+  const portalIds = ['portal-root-id1', 'portal-root-id2']
+
+  configure({ portals: portalIds })
+  const props = { children: childrenTexts, portalIds }
+
+  wrap(MyComponentWithPortals).withProps(props).mount()
+
+  childrenTexts.forEach(childrenText => {
+    expect(document.body).toHaveTextContent(childrenText)
+  })
 })
 
 it('should have unique portals', () => {


### PR DESCRIPTION
## :camera_flash: Screenshots/Gif/Videos
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->

## :tophat: What?
<!--- Describe your changes in detail -->
Add property portals to wrapito config

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To support multiple portals

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->

## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
