### PR TITLE
fix(deps): move tinyspy from devDependencies to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "deep-equal": "^2.2.3",
         "jest-diff": "^29.7.0",
         "object-hash": "^3.0.0",
+        "tinyspy": "^2.2.1",
         "whatwg-fetch": "^3.6.20"
       },
       "devDependencies": {
@@ -38,7 +39,6 @@
         "react-router-dom": "^5.3.4",
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0",
-        "tinyspy": "^2.2.1",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3",
         "vitest": "^1.1.0"
@@ -9320,7 +9320,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
       "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "deep-equal": "^2.2.3",
     "jest-diff": "^29.7.0",
     "object-hash": "^3.0.0",
+    "tinyspy": "^2.2.1",
     "whatwg-fetch": "^3.6.20"
   },
   "devDependencies": {
@@ -82,7 +83,6 @@
     "react-router-dom": "^5.3.4",
     "redux": "^5.0.1",
     "redux-thunk": "^3.1.0",
-    "tinyspy": "^2.2.1",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^1.1.0"


### PR DESCRIPTION
## Summary

Fix a latent **phantom dependency**: `tinyspy` is imported from `src/utils/tinyspyWrapper.ts` and the published `dist/` calls `require("tinyspy")` at runtime, but the package is declared as a `devDependency`. Today it only works in consumers because `vitest` (which every wrapito consumer installs) brings tinyspy transitively and npm hoists it.

## Why this matters

- **Breaks on stricter resolvers.** pnpm with default settings and Yarn PnP don't flatten `node_modules`, so wrapito fails to resolve tinyspy in those projects.
- **Silent version drift.** Consumers receive whatever tinyspy version their `vitest` happens to bring. If that version becomes incompatible with the internal APIs we use (`getInternalState`, `internalSpyOn`), wrapito breaks without any change on its side.
- **Invisible decoupling from vitest's internals.** If a future vitest stops depending on tinyspy or replaces it, every wrapito consumer breaks.

## Changes

`package.json`: move `tinyspy` from `devDependencies` to `dependencies`.

No code changes. `dist/` keeps the same `require("tinyspy")` it already had.

## Risk

Very low. npm and Yarn classic will dedupe the new declared dependency against the existing transitive one (same range), so consumers see no extra install and no version change.

## Test plan

- [x] `npm test` — 82/82 passing
- [x] `npm run build` — `dist/index.js` still externalizes tinyspy via `require("tinyspy")`
- [ ] Install resulting tarball in a real consumer repo to verify resolution under both npm and pnpm

🤖 Generated with [Claude Code](https://claude.com/claude-code)