### PR TITLE
fix(tests): migrate router mocks to react-router-dom v7 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "eslint-config-react-app": "^7.0.1",
         "eslint-plugin-prettier": "^5.5.6",
         "eslint-plugin-react": "^7.37.5",
-        "history": "^4.10.1",
+        "history": "^5.3.0",
         "jsdom": "^26.1.0",
         "prettier": "^3.8.3",
         "react": "^19.2.7",
@@ -6614,18 +6614,13 @@
       }
     },
     "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
+        "@babel/runtime": "^7.7.6"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -8864,13 +8859,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -9583,20 +9571,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -10173,13 +10147,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vitest": {
       "version": "4.1.8",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-config-react-app": "^7.0.1",
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-react": "^7.37.5",
-    "history": "^4.10.1",
+    "history": "^5.3.0",
     "jsdom": "^26.1.0",
     "prettier": "^3.8.3",
     "react": "^19.2.7",

--- a/tests/components.mock.jsx
+++ b/tests/components.mock.jsx
@@ -1,7 +1,7 @@
 import React, { Component, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Provider, useDispatch, useSelector } from 'react-redux'
-import { BrowserRouter, Route, Router, Switch, useLocation } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
 import { createBrowserHistory } from 'history'
 import { applyMiddleware, createStore } from 'redux'
 import { thunk } from 'redux-thunk'
@@ -65,8 +65,9 @@ export const myFakeModule = {
   myFakeFunction: () => null,
 }
 
-const Home = ({ history }) => {
-  const goToCategories = () => history.push('/categories')
+const Home = () => {
+  const navigate = useNavigate()
+  const goToCategories = () => navigate('/categories')
   myFakeModule.myFakeFunction('HOME')
   return (
     <div>
@@ -93,40 +94,28 @@ const PageUsingLocationState = () => {
 export const history = createBrowserHistory()
 
 export const MyAppWithRouting = () => {
+  const pathname = window.location.pathname
+  const state = window.history.state?.usr ?? null
   return (
-    <Router history={history}>
-      <Switch>
-        <Route key="home" path="/" component={Home} exact={true} />
-        <Route
-          key="categories"
-          path="/categories"
-          component={Categories}
-          exact={true}
-        />
-        <Route
-          component={PageUsingLocationState}
-          key="page-using-location-state"
-          path="/page-using-location-state"
-          exact={true}
-        />
-      </Switch>
-    </Router>
+    <MemoryRouter initialEntries={[{ pathname, state }]}>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/categories" element={<Categories />} />
+        <Route path="/page-using-location-state" element={<PageUsingLocationState />} />
+      </Routes>
+    </MemoryRouter>
   )
 }
 
 export const MyAppWithBrowserRouting = () => {
+  const pathname = window.location.pathname
   return (
-    <BrowserRouter>
-      <Switch>
-        <Route key="home" path="/" component={Home} exact={true} />
-        <Route
-          key="categories"
-          path="/categories"
-          component={Categories}
-          exact={true}
-        />
-      </Switch>
-    </BrowserRouter>
+    <MemoryRouter initialEntries={[pathname]}>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/categories" element={<Categories />} />
+      </Routes>
+    </MemoryRouter>
   )
 }
 

--- a/tests/components.mock.jsx
+++ b/tests/components.mock.jsx
@@ -1,7 +1,7 @@
 import React, { Component, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Provider, useDispatch, useSelector } from 'react-redux'
-import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
+import { BrowserRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
 import { createBrowserHistory } from 'history'
 import { applyMiddleware, createStore } from 'redux'
 import { thunk } from 'redux-thunk'
@@ -94,28 +94,25 @@ const PageUsingLocationState = () => {
 export const history = createBrowserHistory()
 
 export const MyAppWithRouting = () => {
-  const pathname = window.location.pathname
-  const state = window.history.state?.usr ?? null
   return (
-    <MemoryRouter initialEntries={[{ pathname, state }]}>
+    <BrowserRouter>
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/categories" element={<Categories />} />
         <Route path="/page-using-location-state" element={<PageUsingLocationState />} />
       </Routes>
-    </MemoryRouter>
+    </BrowserRouter>
   )
 }
 
 export const MyAppWithBrowserRouting = () => {
-  const pathname = window.location.pathname
   return (
-    <MemoryRouter initialEntries={[pathname]}>
+    <BrowserRouter>
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/categories" element={<Categories />} />
       </Routes>
-    </MemoryRouter>
+    </BrowserRouter>
   )
 }
 


### PR DESCRIPTION
## Summary

Fixes the 6 failing tests in [#347](https://github.com/mercadona/wrapito/pull/347) caused by the v5→v7 breaking API changes in react-router-dom.

### What changed

| Before (v5) | After (v7) |
|---|---|
| \`<Router history={history}>\` | \`<BrowserRouter>\` |
| \`<Switch>\` | \`<Routes>\` |
| \`<Route component={X}>\` | \`<Route element={<X />}>\` |
| \`Home({ history })\` prop | \`useNavigate()\` hook |
| \`history@^4\` devDep | \`history@^5\` (state stored as \`.usr\`, compatible with \`useLocation().state\` in v6/v7) |

### Why history@^5

history v4 stores user state as \`window.history.state.state\`; react-router v6/v7 reads \`useLocation().state\` from \`window.history.state.usr\`. Upgrading to v5 aligns the storage format so the location-state test passes correctly.

## Test plan

- [x] \`npm test -- --exclude "**/.claude/**"\` → 82/82 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)