### PR TITLE
chore(deps-dev): migrate from legacy Redux to Redux Toolkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "0.18.3",
+        "@reduxjs/toolkit": "^2.12.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/deep-equal": "^1.0.4",
@@ -37,8 +38,6 @@
         "react-dom": "^19.2.7",
         "react-redux": "^9.3.0",
         "react-router-dom": "^7.17.0",
-        "redux": "^5.0.1",
-        "redux-thunk": "^3.1.0",
         "tinyspy": "^2.2.1",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3",
@@ -3086,6 +3085,33 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
@@ -3737,6 +3763,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "dev": true,
       "license": "MIT"
     },
@@ -6967,6 +7000,17 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -9183,6 +9227,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.3",
+    "@reduxjs/toolkit": "^2.12.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/deep-equal": "^1.0.4",
@@ -88,8 +89,6 @@
     "react-dom": "^19.2.7",
     "react-redux": "^9.3.0",
     "react-router-dom": "^7.17.0",
-    "redux": "^5.0.1",
-    "redux-thunk": "^3.1.0",
     "tinyspy": "^2.2.1",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",

--- a/tests/components.mock.jsx
+++ b/tests/components.mock.jsx
@@ -3,8 +3,7 @@ import { createPortal } from 'react-dom'
 import { Provider, useDispatch, useSelector } from 'react-redux'
 import { BrowserRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
 import { createBrowserHistory } from 'history'
-import { applyMiddleware, createStore } from 'redux'
-import { thunk } from 'redux-thunk'
+import { configureStore, createSlice } from '@reduxjs/toolkit'
 
 export const MyComponent = () => <div>Foo</div>
 
@@ -116,30 +115,16 @@ export const MyAppWithBrowserRouting = () => {
   )
 }
 
-const ACTION_TYPES = {
-  ADD: 'ADD',
-  REMOVE: 'REMOVE',
-}
+const cartSlice = createSlice({
+  name: 'cart',
+  initialState: { products: 10 },
+  reducers: {
+    add: state => { state.products += 1 },
+    remove: state => { state.products -= 1 },
+  },
+})
 
-const add = () => ({ type: ACTION_TYPES.ADD })
-const remove = () => dispatch => dispatch({ type: ACTION_TYPES.REMOVE })
-
-function reducer(state = { products: 10 }, action) {
-  switch (action.type) {
-    case ACTION_TYPES.ADD:
-      return {
-        products: state.products + 1,
-      }
-
-    case ACTION_TYPES.REMOVE:
-      return {
-        products: state.products - 1,
-      }
-
-    default:
-      return state
-  }
-}
+const { add, remove } = cartSlice.actions
 
 const Cart = () => {
   const { products } = useSelector(state => state)
@@ -157,7 +142,7 @@ const Cart = () => {
 export const MyAppWithStore = () => {
   return (
     <Provider
-      store={createStore(reducer, { products: 10 }, applyMiddleware(thunk))}
+      store={configureStore({ reducer: cartSlice.reducer, preloadedState: { products: 10 } })}
     >
       <Cart />
     </Provider>


### PR DESCRIPTION
## Summary

- Replaces `redux` + `redux-thunk` (direct devDependencies) with `@reduxjs/toolkit`, which bundles both internally
- Swaps deprecated `createStore` + `applyMiddleware` for RTK's `configureStore`
- Replaces manual `ACTION_TYPES` constants + `switch/case` reducer with `createSlice` (Immer-powered mutations)
- All 3 existing Redux integration tests pass unchanged

## Changes

| File | What changed |
|---|---|
| `package.json` | Add `@reduxjs/toolkit`, remove `redux` and `redux-thunk` |
| `tests/components.mock.jsx` | Use `configureStore` + `createSlice` instead of legacy patterns |

## Test plan

- [x] `tests/appWithStore.test.ts` — 3/3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)