### PR TITLE
chore(deps): add @eslint/* to the dependabot eslint group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,7 @@ updates:
       eslint:
         patterns:
           - "eslint"
+          - "@eslint/*"
           - "@typescript-eslint/*"
           - "eslint-plugin-*"
       testing:


### PR DESCRIPTION
## Why

Dependabot opened two separate PRs for the ESLint 10 major: #348 (the `eslint` group) and #361 (`@eslint/js` alone). The `eslint` group patterns (`eslint`, `@typescript-eslint/*`, `eslint-plugin-*`) don't match the scoped `@eslint/js` package, since `"eslint"` is an exact-name match.

`@eslint/js` ships from the ESLint monorepo and is version-locked to `eslint` (10.x ↔ 10.x), so merging those PRs independently would leave a mismatched pair.

## What

Add `@eslint/*` to the `eslint` group patterns so scoped ESLint packages update together with `eslint` itself. This also covers other `@eslint/`-scoped packages if adopted later.

## After merging

Comment `@dependabot recreate` on #348 — Dependabot will rebuild it with `@eslint/js` included and close #361 automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)