### PR TITLE
chore(deps-dev): bump prettier to 3.9.6 and reformat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "globals": "^17.6.0",
         "history": "^5.3.0",
         "jsdom": "^29.1.1",
-        "prettier": "^3.8.3",
+        "prettier": "^3.9.6",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-redux": "^9.3.0",
@@ -6513,9 +6513,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "globals": "^17.6.0",
     "history": "^5.3.0",
     "jsdom": "^29.1.1",
-    "prettier": "^3.8.3",
+    "prettier": "^3.9.6",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-redux": "^9.3.0",

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -17,9 +17,7 @@ interface MockResultThrow {
   value: any
 }
 type MockResult<T> =
-  | MockResultReturn<T>
-  | MockResultThrow
-  | MockResultIncomplete
+  MockResultReturn<T> | MockResultThrow | MockResultIncomplete
 interface MockContext<TArgs, TReturns> {
   /**
    * This is an array containing all arguments for each call. One item of the array is the arguments of that call.


### PR DESCRIPTION
Arregla el fallo de CI de [#407](https://github.com/mercadona/wrapito/pull/407) ([run](https://github.com/mercadona/wrapito/actions/runs/31684548283/job/94397444425)).

## La causa

Prettier 3.9.6 cambia cómo formatea una unión multilínea que cabe en una línea: quita los pipes iniciales y junta los miembros en una sola línea indentada. En el repo solo afecta a una declaración, `MockResult<T>` en `src/utils/types.ts`:

```diff
 type MockResult<T> =
-  | MockResultReturn<T>
-  | MockResultThrow
-  | MockResultIncomplete
+  MockResultReturn<T> | MockResultThrow | MockResultIncomplete
```

Como `eslint-plugin-prettier` convierte eso en un error de lint, `npm run lint` falla y tumba el job.

## Por qué el bump y el reformateo van juntos

Las dos versiones se contradicen **en ambos sentidos**, comprobado en local:

| Formato | prettier 3.8.4 | prettier 3.9.6 |
|---|---|---|
| pipes iniciales, multilínea | acepta | **rechaza** |
| colapsado en una línea | **rechaza** | acepta |

Por eso no se puede aislar el reformateo en un PR sobre `master`: rompería el lint con la 3.8.4 que hay hoy. Y bumpear sin reformatear es exactamente lo que falla ahora en #407. Tienen que ir en el mismo commit.

## Efecto sobre #407

Este PR se lleva `prettier` fuera del grupo `minors`. Al mergear esto, #407 hay que recrearlo (o cerrarlo y dejar que dependabot lo rehaga) y quedará con `globals` y `typescript-eslint` solamente.

## Verificación

Pipeline completo del CI en local:

- `npm run lint` → **0 errores** (quedan 3 warnings de `complexity` preexistentes, ajenos a este cambio)
- `npx vitest run` → **14 archivos, 94 tests passing, no type errors**
- `npm run build` → OK
- `npm run check:exports` → los 4 targets en verde

Generated with Claude Code