### PR TITLE
ci: check that CJS bundle deps are actually requirable

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,3 +21,4 @@ jobs:
           npm run test
           npm run build
           npm run check:exports
+          npm run check:cjs-deps

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "publish-package:beta": "npm run build && npm publish --tag beta",
     "typecheck": "tsc --noEmit dist/index.d.ts",
     "check:exports": "attw --pack .",
-    "prepublishOnly": "npm run build && npm run check:exports"
+    "check:cjs-deps": "node scripts/check-cjs-deps.js",
+    "prepublishOnly": "npm run build && npm run check:exports && npm run check:cjs-deps"
   },
   "repository": {
     "type": "git",

--- a/scripts/check-cjs-deps.js
+++ b/scripts/check-cjs-deps.js
@@ -1,0 +1,147 @@
+/**
+ * Guards the CJS half of the dual ESM/CJS build.
+ *
+ * tsup externalises dependencies, so `dist/index.cjs` ships bare `require()`
+ * calls that only resolve at consumer runtime. When a dependency publishes an
+ * ESM-only major, that bundle breaks for every CommonJS consumer:
+ *
+ *   - Node < 22.12: `require()` throws ERR_REQUIRE_ESM.
+ *   - Node >= 22.12: `require()` returns a module namespace, so esbuild's
+ *     interop helper leaves `chalk.white` undefined and the first property
+ *     access throws a TypeError.
+ *
+ * Type-level checks cannot see this: these deps never reach our public type
+ * surface. chalk@5 was the first one to bite us.
+ *
+ * Run after `npm run build`.
+ */
+import { builtinModules, createRequire } from 'node:module'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { dirname, join, parse, relative, resolve } from 'node:path'
+
+const DIST = resolve('dist')
+const BARE_REQUIRE = /require\(\s*["']([^"']+)["']\s*\)/g
+
+const isBuiltin = specifier =>
+  specifier.startsWith('node:') || builtinModules.includes(specifier)
+
+const isRelative = specifier =>
+  specifier.startsWith('.') || specifier.startsWith('/')
+
+const externalSpecifiersIn = source => {
+  const specifiers = new Set()
+
+  for (const [, specifier] of source.matchAll(BARE_REQUIRE)) {
+    if (isRelative(specifier) || isBuiltin(specifier)) continue
+    specifiers.add(specifier)
+  }
+
+  return specifiers
+}
+
+/* Nearest package.json wins, exactly as Node decides a .js file's format. */
+const packageTypeFor = filePath => {
+  const { root } = parse(filePath)
+  let directory = dirname(filePath)
+
+  while (true) {
+    const manifest = join(directory, 'package.json')
+
+    if (existsSync(manifest)) {
+      try {
+        return JSON.parse(readFileSync(manifest, 'utf8')).type ?? 'commonjs'
+      } catch {
+        return 'commonjs'
+      }
+    }
+
+    if (directory === root) return 'commonjs'
+    directory = dirname(directory)
+  }
+}
+
+const isEsm = filePath => {
+  if (filePath.endsWith('.mjs')) return true
+  /* .cjs, .node and .json are never ESM. */
+  if (!filePath.endsWith('.js')) return false
+
+  return packageTypeFor(filePath) === 'module'
+}
+
+const bundles = existsSync(DIST)
+  ? readdirSync(DIST)
+      .filter(file => file.endsWith('.cjs'))
+      .map(file => join(DIST, file))
+  : []
+
+if (!bundles.length) {
+  console.error('✖ No CJS bundle found in dist. Run `npm run build` first.')
+  process.exit(1)
+}
+
+const problems = []
+let checked = 0
+
+for (const bundle of bundles) {
+  const requireFromBundle = createRequire(bundle)
+
+  for (const specifier of externalSpecifiersIn(readFileSync(bundle, 'utf8'))) {
+    checked++
+
+    let resolved
+    try {
+      resolved = requireFromBundle.resolve(specifier)
+    } catch (error) {
+      problems.push({
+        specifier,
+        bundle,
+        reason: `is not resolvable under the \`require\` condition (${error.code ?? error.message})`,
+      })
+      continue
+    }
+
+    if (isEsm(resolved)) {
+      problems.push({
+        specifier,
+        bundle,
+        reason: `resolves to an ES module (${relative(process.cwd(), resolved)})`,
+      })
+    }
+  }
+}
+
+/*
+ * A pass has to mean something. Zero matches means tsup stopped externalising
+ * deps or changed its output shape, not that the bundle is safe.
+ */
+if (!checked) {
+  console.error('✖ Found no external require() calls in the CJS bundle.')
+  console.error(
+    '  Either tsup stopped externalising dependencies or its output shape',
+  )
+  console.error(
+    '  changed and BARE_REQUIRE no longer matches. Refusing to report a pass.',
+  )
+  process.exit(1)
+}
+
+if (problems.length) {
+  console.error(
+    `✖ The CJS bundle require()s ${problems.length} module(s) that CommonJS consumers cannot load:\n`,
+  )
+
+  for (const { specifier, bundle, reason } of problems) {
+    console.error(`  ${specifier} ${reason}`)
+    console.error(`    required by ${relative(process.cwd(), bundle)}`)
+  }
+
+  console.error(
+    '\n  Pin the dependency to its last CJS-capable major, or stop importing it',
+  )
+  console.error('  from code that ends up in the CJS bundle.')
+  process.exit(1)
+}
+
+console.log(
+  `✔ All ${checked} externalised dependencies in the CJS bundle resolve to CommonJS.`,
+)


### PR DESCRIPTION
## What

Adds `scripts/check-cjs-deps.js` plus a `check:cjs-deps` npm script, wired into CI after `npm run build` and into `prepublishOnly`.

## Why

tsup externalises dependencies, so `dist/index.cjs` ships bare `require()` calls that only resolve at consumer runtime:

```js
require("chalk")  require("object-hash")  require("deep-equal")
require("jest-diff")  require("react")  require("@testing-library/react")
```

Nothing in CI verified those resolve to something a CommonJS consumer can load. `chalk@5` slipped through exactly this gap, and `node-fetch`, `nanoid` and the `unified` ecosystem are the same story waiting to happen.

## What it does

Reads every bare specifier out of the built CJS bundle, resolves it **under the `require` condition from the bundle's own location**, and fails when it lands on an ES module or doesn't resolve at all.

Green on `chalk@4`:

```
✔ All 6 externalised dependencies in the CJS bundle resolve to CommonJS.
```

Red on `chalk@5`:

```
✖ The CJS bundle require()s 1 module(s) that CommonJS consumers cannot load:

  chalk resolves to an ES module (node_modules/chalk/source/index.js)
    required by dist/index.cjs

  Pin the dependency to its last CJS-capable major, or stop importing it
  from code that ends up in the CJS bundle.
```

`attw --pack .` reports `No problems found 🌟` on that same build — it checks type resolution of our own entrypoints, and `chalk` never reaches our public type surface. Details in #412.

## Design notes

- **Format detection matches Node's.** Walks up to the nearest `package.json` for a `type` field. `.mjs` is ESM; `.cjs`, `.node` and `.json` never are; `.js` depends on the nearest manifest.
- **Zero matches fails instead of passing.** If tsup stops externalising deps or changes its output shape, a green check would be meaningless, so it refuses to report one. This is the guard against the regex silently rotting.
- **No-`require`-condition deps are covered too.** A dep whose exports map only has `import` makes `require.resolve` throw `ERR_PACKAGE_PATH_NOT_EXPORTED`, and the specifier gets reported.
- **Peer deps are checked.** `react` and `@testing-library/react` resolve from our `node_modules` rather than a consumer's, which is an approximation — but an ESM-only major there breaks the CJS bundle just the same.

No new dependency; it's stdlib only. `files: ["dist"]` already keeps `scripts/` out of the published tarball.

## Why not a runtime smoke test

The obvious alternative — `node -e "require('./dist/index.cjs')"` — doesn't work here. [src/wrap.tsx:19](https://github.com/mercadona/wrapito/blob/master/src/wrap.tsx#L19) calls `beforeEach`/`afterEach` at module top level, so requiring the bundle outside a test runner dies with `ReferenceError: beforeEach is not defined` before it ever reaches `chalk`. Making that work means either importing `dist` from a vitest test (needs build-before-test in CI) or moving the global hooks to an opt-in setup file (breaking change). Static resolution gets the same signal without either.

## Verification

- `npm run lint` → 0 errors (3 pre-existing `complexity` warnings)
- `npm run test` → 14 files, 94 tests passed, no type errors
- Full CI sequence green: `lint` → `test` → `build` → `check:exports` → `check:cjs-deps`
- Goes red on `chalk@5` as shown above
- Both error paths exercised: missing `dist` → exit 1; bundle with no external requires → exit 1

## Note on #412

Independent of #412 (which removes attw) — this one stands on its own whether attw stays or goes. They do touch adjacent lines in `package.json` scripts and `integration.yml`, so whichever lands second needs a trivial rebase.

Generated with Claude Code