### PR TITLE
build(deps): stop dependabot proposing chalk major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,13 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      # chalk is ESM-only from 5.0.0 (4.1.2 is the last CJS release). tsup
+      # externalises it, so dist/index.cjs ships a bare require("chalk") that
+      # breaks every CommonJS consumer. CI never runs the CJS bundle, so a
+      # major bump lands green.
+      - dependency-name: "chalk"
+        update-types: ["version-update:semver-major"]
     groups:
       patches:
         applies-to: version-updates


### PR DESCRIPTION
## What

One `ignore` rule in `.github/dependabot.yml` so Dependabot never opens a chalk major-version PR.

```yaml
ignore:
  - dependency-name: "chalk"
    update-types: ["version-update:semver-major"]
```

## Why

chalk is ESM-only from 5.0.0 — 4.1.2 is the last CJS release, latest is 6.0.0. tsup externalises it, so `dist/index.cjs` ships a bare `require("chalk")` that only resolves on the consumer's machine. A major bump breaks every CommonJS consumer:

- **Node < 22.12** — `require()` throws `ERR_REQUIRE_ESM` on import.
- **Node ≥ 22.12** — `require()` returns a module namespace instead of throwing, so `chalk.white` ends up undefined and the failure surfaces later, inside [printRequest()](https://github.com/mercadona/wrapito/blob/master/src/mockNetwork.ts#L55), as `TypeError: Cannot read properties of undefined (reading 'bold')`. That's the path that reports unmatched mocks — consumers get a TypeError from wrapito's internals precisely when they were already debugging a missing mock.

The reason this needs blocking in config rather than at review time: **nothing here executes the CJS bundle.** Tests import from `src/`, not `dist/`. So the bump arrives with a green tick and looks safe to merge.

## Scope

Semver-major only. Patch and minor within 4.x still flow through the existing `patches`/`minors` groups.

The durable fix is a CI check that the CJS bundle's dependencies are requirable (#413); this rule holds the line until then, and shouldn't be lifted before it.

One limit worth knowing: the rule covers version updates. If chalk ever gets a CVE fixed only in ≥5, this shouldn't be what stops us reacting.

## Verification

YAML parses; `ignore` sits at the correct depth in the npm `updates` entry. Parsed rule: `[{"dependency-name":"chalk","update-types":["version-update:semver-major"]}]`.

Generated with Claude Code